### PR TITLE
Make trailing slash in Bridge LTI launch URLs optional

### DIFF
--- a/bridge-adaptivity/adaptive_edx/settings/base.py
+++ b/bridge-adaptivity/adaptive_edx/settings/base.py
@@ -71,7 +71,7 @@ TEMPLATES = [{
     'DIRS': [
         normpath(join(SITE_ROOT, 'templates')),
     ],
-    'OPTIONS':{
+    'OPTIONS': {
         'context_processors': [
             'django.contrib.auth.context_processors.auth',
             'django.template.context_processors.request',  # adds `request` object to templates context
@@ -81,16 +81,13 @@ TEMPLATES = [{
             'django.template.loaders.filesystem.Loader',
             'django.template.loaders.app_directories.Loader',
         ],
-        'debug':True,
+        'debug': True,
     },
 }]
-
-LOGIN_URL = reverse_lazy('lti_auth_error')
 
 ROOT_URLCONF = 'adaptive_edx.urls'
 
 WSGI_APPLICATION = 'adaptive_edx.wsgi.application'
-
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
@@ -131,6 +128,8 @@ AUTH_USER_MODEL = 'bridge_lti.BridgeUser'
 LOGIN_URL = 'login'
 LOGIN_REDIRECT_URL = 'module:collection-list'
 ALLOWED_HOSTS = secure.ALLOWED_HOSTS
+
+APPEND_SLASH = False
 
 DATABASES = secure.DATABASES
 

--- a/bridge-adaptivity/adaptive_edx/settings/base.py
+++ b/bridge-adaptivity/adaptive_edx/settings/base.py
@@ -11,8 +11,8 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 from os.path import abspath, basename, dirname, join, normpath
-from django.core.urlresolvers import reverse_lazy
 from sys import path
+
 import secure
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/bridge-adaptivity/bridge_lti/consumer.py
+++ b/bridge-adaptivity/bridge_lti/consumer.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
@@ -26,6 +27,7 @@ def tool_config(request):
     return HttpResponse(lti_tool_config.to_xml(), content_type='text/xml')
 
 
+@login_required
 def source_preview(request):
     """
     Simple view to render Source content block shared through LTI.

--- a/bridge-adaptivity/bridge_lti/provider.py
+++ b/bridge-adaptivity/bridge_lti/provider.py
@@ -68,4 +68,3 @@ def lti_launch(request, collection_id=None):
         sequence_item = sequence.sequenceitem_set.last()
 
     return redirect(reverse('module:sequence-item', kwargs={'pk': sequence_item.id}))
-

--- a/bridge-adaptivity/bridge_lti/provider.py
+++ b/bridge-adaptivity/bridge_lti/provider.py
@@ -6,7 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from bridge_lti.validator import SignatureValidator
 from module.models import (Collection, Sequence, SequenceItem)
 from .models import LtiProvider, LtiUser
-from .utils import get_required_params, get_optional_params
+from .utils import get_required_params, get_optional_params, LtiRole
 
 
 @csrf_exempt
@@ -31,37 +31,41 @@ def lti_launch(request, collection_id=None):
     if not SignatureValidator(lti_consumer).verify(request):
         return HttpResponseForbidden()
 
-    if params['roles'] in ['Student', 'Learner']:
+    if LtiRole(params['roles']).is_instructor:
         if not collection_id:
-            return render(request, template_name="bridge_lti/announcement.html")
-        try:
-            collection = Collection.objects.get(id=collection_id)
-        except Collection.DoesNotExist:
-            return HttpResponseBadRequest()
+            return redirect(reverse('module:collection-list'))
 
-        lti_user, created = LtiUser.objects.get_or_create(
-            user_id=params['user_id'],
-            lti_consumer=lti_consumer,
-            defaults={'course_id': params['context_id']}
+        return redirect(reverse('module:collection-detail', kwargs={'pk': collection_id}))
+
+    if not collection_id:
+        return render(request, template_name="bridge_lti/announcement.html")
+
+    try:
+        collection = Collection.objects.get(id=collection_id)
+    except Collection.DoesNotExist:
+        return HttpResponseBadRequest()
+
+    lti_user, created = LtiUser.objects.get_or_create(
+        user_id=params['user_id'],
+        lti_consumer=lti_consumer,
+        defaults={'course_id': params['context_id']}
+    )
+    sequence, created = Sequence.objects.get_or_create(
+        lti_user=lti_user,
+        collection=collection
+    )
+
+    if sequence.completed:
+        return redirect(reverse('module:sequence-complete', kwargs={'pk': sequence.id}))
+
+    if created:
+        sequence_item = SequenceItem.objects.create(
+            sequence=sequence,
+            activity=collection.activity_set.first(),
+            position=1
         )
-        sequence, created = Sequence.objects.get_or_create(
-            lti_user=lti_user,
-            collection=collection
-        )
-
-        if sequence.completed:
-            return redirect(reverse('module:sequence-complete', kwargs={'pk': sequence.id}))
-
-        if created:
-            sequence_item = SequenceItem.objects.create(
-                sequence=sequence,
-                activity=collection.activity_set.first(),
-                position=1
-            )
-        else:
-            sequence_item = sequence.sequenceitem_set.last()
-
-        return redirect(reverse('module:sequence-item', kwargs={'pk': sequence_item.id}))
-
     else:
-        return redirect(reverse('module:collection-list'))
+        sequence_item = sequence.sequenceitem_set.last()
+
+    return redirect(reverse('module:sequence-item', kwargs={'pk': sequence_item.id}))
+

--- a/bridge-adaptivity/bridge_lti/provider.py
+++ b/bridge-adaptivity/bridge_lti/provider.py
@@ -76,7 +76,8 @@ def lti_launch(request, collection_id=None):
     try:
         collection = Collection.objects.get(id=collection_id)
     except Collection.DoesNotExist:
-        return HttpResponseBadRequest()
+        log.exception("Collection with provided ID does not exist. Check configured launch url.")
+        return HttpResponseBadRequest(reason='Bad launch_url collection ID.')
 
     lti_user, created = LtiUser.objects.get_or_create(
         user_id=params['user_id'],

--- a/bridge-adaptivity/bridge_lti/urls.py
+++ b/bridge-adaptivity/bridge_lti/urls.py
@@ -5,7 +5,7 @@ from .provider import lti_launch
 from .consumer import source_preview
 
 urlpatterns = [
-    url(r'^launch$', lti_launch, name='initial-launch'),
-    url(r'^launch/(?P<collection_id>\d+)$', lti_launch, name='launch'),
+    url(r'^launch/?$', lti_launch, name='initial-launch'),
+    url(r'^launch/(?P<collection_id>\d+)/?$', lti_launch, name='launch'),
     url(r'^source/$', login_required(source_preview), name='source-preview'),
 ]

--- a/bridge-adaptivity/bridge_lti/urls.py
+++ b/bridge-adaptivity/bridge_lti/urls.py
@@ -5,6 +5,6 @@ from .provider import lti_launch
 from .consumer import source_preview
 
 urlpatterns = [
-    url(r'^launch/?(/(?P<collection_id>\d+))?/?$', lti_launch, name='launch'),
+    url(r'^launch/(?P<collection_id>\d*)$', lti_launch, name='launch'),
     url(r'^source/$', login_required(source_preview), name='source-preview'),
 ]

--- a/bridge-adaptivity/bridge_lti/urls.py
+++ b/bridge-adaptivity/bridge_lti/urls.py
@@ -5,7 +5,6 @@ from .provider import lti_launch
 from .consumer import source_preview
 
 urlpatterns = [
-    url(r'^launch/?$', lti_launch, name='initial-launch'),
-    url(r'^launch/(?P<collection_id>\d+)/?$', lti_launch, name='launch'),
+    url(r'^launch/?(/(?P<collection_id>\d+))?/?$', lti_launch, name='launch'),
     url(r'^source/$', login_required(source_preview), name='source-preview'),
 ]

--- a/bridge-adaptivity/bridge_lti/urls.py
+++ b/bridge-adaptivity/bridge_lti/urls.py
@@ -1,10 +1,9 @@
 from django.conf.urls import url
-from django.contrib.auth.decorators import login_required
 
 from .provider import lti_launch
 from .consumer import source_preview
 
 urlpatterns = [
     url(r'^launch/(?P<collection_id>\d*)$', lti_launch, name='launch'),
-    url(r'^source/$', login_required(source_preview), name='source-preview'),
+    url(r'^source/$', source_preview, name='source-preview'),
 ]

--- a/bridge-adaptivity/bridge_lti/utils.py
+++ b/bridge-adaptivity/bridge_lti/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import string
 
 import shortuuid
 from django.conf import settings
@@ -13,6 +14,53 @@ OPTIONAL_PARAMETERS = [
     'lis_outcome_service_url',
     'tool_consumer_instance_guid'
 ]
+
+
+class LtiRole(object):
+    """
+    Constant for LTI roles.
+
+    Reference: https://www.imsglobal.org/specs/ltiv1p1p1/implementation-guide#toc-11
+    """
+    LTI_ROLES = {
+        "Learner": {"learner", "student"},
+        "Instructor": {"instructor"},
+        "Administrator": {"administrator"},
+        "TeachingAssistant": {"teachingassistant"},
+        "ContentDeveloper": {"contentdeveloper"},
+        "Mentor": {"mentor"}
+    }
+
+    def __init__(self, roles_param):
+        self.roles = map(string.lower, roles_param.split(",")) if roles_param else []
+
+    @property
+    def is_undefined(self):
+        return not bool(self.roles)
+
+    @property
+    def is_learner(self):
+        return self.LTI_ROLES["Learner"].intersection(self.roles)
+
+    @property
+    def is_instructor(self):
+        return self.LTI_ROLES["Instructor"].intersection(self.roles)
+
+    @property
+    def is_administrator(self):
+        return self.LTI_ROLES["Administrator"].intersection(self.roles)
+
+    @property
+    def is_assistant(self):
+        return self.LTI_ROLES["TeachingAssistant"].intersection(self.roles)
+
+    @property
+    def is_content_developer(self):
+        return self.LTI_ROLES["ContentDeveloper"].intersection(self.roles)
+
+    @property
+    def is_mentor(self):
+        return self.LTI_ROLES["Mentor"].intersection(self.roles)
 
 
 def short_token():


### PR DESCRIPTION
- Made LTI launch URL to catch:
-- lti/launch;
-- lti/launch/;
-- lti/launch/1;
-- lti/launch/1/;
- Refactor Instructor to be redirected to:
-- collections list view by the base lti url (w/o collection_id);
-- specific collection detail view by the lti url with provided collection_id.