### PR TITLE
Update example secure settings file

### DIFF
--- a/bridge-adaptivity/adaptive_edx/settings/secure.py.example
+++ b/bridge-adaptivity/adaptive_edx/settings/secure.py.example
@@ -7,4 +7,6 @@ Should be ignored by VCS (Git).
 # Standard Django secret key (can be generated via http://www.miniwebtool.com/django-secret-key-generator/)
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = 'your_generated_django_secret-key'
-HOST = {}
+STATIC_ROOT = ''
+ALLOWED_HOSTS = ['localhost']
+DATABASES = {}


### PR DESCRIPTION
Update example secure settings file with values. Base settings file requires some placeholder values to be present even if running locally.

Resolves #20 