### PR TITLE
Add deployment config

### DIFF
--- a/bridge_adaptivity/.ebextensions/cwlogs.config
+++ b/bridge_adaptivity/.ebextensions/cwlogs.config
@@ -1,0 +1,20 @@
+# delete awslogs agent state file so that agent starts monitoring logs
+# for the most recently created container
+
+files:
+    /opt/elasticbeanstalk/hooks/appdeploy/post/99_delete_awslogs_agent_state.sh:
+        mode: "000755"
+        owner: root
+        group: root
+        content: |
+            #!/bin/bash
+
+            # delete awslogs agent state file so that agent starts monitoring logs
+            # for the most recently created container
+
+            AGENTSTATE="/var/lib/awslogs/agent-state"
+            if [ -e $AGENTSTATE ]
+            then
+                sudo rm $AGENTSTATE
+                sudo service awslogs restart
+            fi

--- a/bridge_adaptivity/.ebextensions/nginx.config
+++ b/bridge_adaptivity/.ebextensions/nginx.config
@@ -1,0 +1,47 @@
+files:
+    /etc/nginx/sites-enabled/elasticbeanstalk-nginx-docker-proxy.conf:
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+            map $http_upgrade $connection_upgrade {
+                default        "upgrade";
+                ""            "";
+            }
+
+            server {
+                listen 80;
+
+                gzip on;
+                    gzip_comp_level 4;
+                    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+                if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+                    set $year $1;
+                    set $month $2;
+                    set $day $3;
+                    set $hour $4;
+                }
+                access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
+
+                access_log    /var/log/nginx/access.log;
+
+                location / {
+                    proxy_pass            http://docker;
+                    proxy_http_version    1.1;
+
+                    proxy_set_header    Connection            $connection_upgrade;
+                    proxy_set_header    Upgrade                $http_upgrade;
+                    proxy_set_header    Host                $host;
+                    proxy_set_header    X-Real-IP            $remote_addr;
+                    proxy_set_header    X-Forwarded-For        $proxy_add_x_forwarded_for;
+                }
+
+                location /static {
+                    alias /var/app/current/static;
+                }
+            }
+
+commands:
+    restart_nginx:
+        command: /etc/init.d/nginx restart

--- a/bridge_adaptivity/Dockerfile
+++ b/bridge_adaptivity/Dockerfile
@@ -13,3 +13,10 @@ RUN pip install -Ur requirements.txt
 
 # Make static media dir:
 RUN mkdir -p /www/static
+
+# Make sure entrypoint script is executable
+RUN ["chmod", "+x", "run_container.sh"]
+
+EXPOSE 8000
+
+CMD ["./run_container.sh"]

--- a/bridge_adaptivity/config/settings/base.py
+++ b/bridge_adaptivity/config/settings/base.py
@@ -100,14 +100,6 @@ USE_TZ = True
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-# Additional locations of static files
-STATICFILES_DIRS = (
-    # Put strings here, like "/home/html/static" or "C:/www/django/static".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-    normpath(join(SITE_ROOT, 'static')),
-)
-
 STATIC_URL = '/static/'
 
 # django-bootstrap:

--- a/bridge_adaptivity/config/settings/local.py
+++ b/bridge_adaptivity/config/settings/local.py
@@ -39,7 +39,7 @@ MIDDLEWARE_CLASSES += (
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 STATIC_URL = '/static/'
-STATIC_ROOT = normpath(join(SITE_ROOT, 'http_static'))
+STATIC_ROOT = normpath(join(SITE_ROOT, 'static'))
 
 # For Django Debug Toolbar:
 # NOTE(idegtiarov) In order to make dgango-debug-toolbar works with docker add here docker machine ip address.

--- a/bridge_adaptivity/config/settings/prod.py
+++ b/bridge_adaptivity/config/settings/prod.py
@@ -1,0 +1,49 @@
+"""
+docker-compose deployment on production machine
+"""
+
+# flake8: noqa: F405
+from base import *  # noqa: F401,F403
+import secure
+
+SECRET_KEY = secure.SECRET_KEY
+ALLOWED_HOSTS = secure.ALLOWED_HOSTS
+STATIC_ROOT = '/www/static/'
+DATABASES = secure.DATABASES
+
+# Configure Bridge host with is used for lis_outcome_service_url composition
+BRIDGE_HOST = secure.BRIDGE_HOST
+
+try:
+    # Engine for Adaptivity configuration block
+    # ENGINE_MODULE is a string with the path to the engine module
+    ENGINE_MODULE = secure.ENGINE_MODULE
+
+    # ENGINE_DRIVER is a string with the name of driver class in the engine module
+    ENGINE_DRIVER = secure.ENGINE_DRIVER
+
+    # ENGINE_SETTINGS is a dict, with the initial params for driver initialization
+    ENGINE_SETTINGS = secure.ENGINE_SETTINGS
+except AttributeError:
+    # Default Mock engine will be used
+    pass
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+        'logfile': {
+            'level': 'WARNING',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': BASE_DIR + "/bridge-error.log",
+        },
+    },
+    'root': {
+        'level': 'INFO',
+        'handlers': ['console', 'logfile']
+    },
+}

--- a/bridge_adaptivity/config/wsgi.py
+++ b/bridge_adaptivity/config/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.base")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
 
 application = get_wsgi_application()

--- a/bridge_adaptivity/prod_run.sh
+++ b/bridge_adaptivity/prod_run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-python manage.py migrate --settings=config.settings.base
-python manage.py collectstatic -v 3 -c --noinput --settings=config.settings.base
+python manage.py migrate --settings=config.settings.prod
+python manage.py collectstatic -v 3 -c --noinput --settings=config.settings.prod
 sleep 5 && /usr/local/bin/gunicorn config.wsgi:application -w 2 -b :8000 --log-file=/dev/stdout --log-level=info --access-logfile=/dev/stdout


### PR DESCRIPTION
Adds some deployment configuration for single docker container elastic beanstalk deployments. Also adds a prod.py settings module that can be used for general production deployments, instead of using base.py directly as the DJANGO_SETTINGS_MODULE.