### PR TITLE
Populate session variables on lti launch even when sequence is complete

### DIFF
--- a/bridge_adaptivity/bridge_lti/provider.py
+++ b/bridge_adaptivity/bridge_lti/provider.py
@@ -98,12 +98,13 @@ def learner_flow(request, lti_consumer, tool_provider, collection_id=None):
         collection=collection
     )
 
-    if sequence.completed:
-        log.debug("Sequence {} is already completed".format(sequence.id))
-        return redirect(reverse('module:sequence-complete', kwargs={'pk': sequence.id}))
     strict_forward = collection.strict_forward
     request.session['Lti_sequence'] = sequence.id
     request.session['Lti_strict_forward'] = strict_forward
+
+    if sequence.completed:
+        log.debug("Sequence {} is already completed".format(sequence.id))
+        return redirect(reverse('module:sequence-complete', kwargs={'pk': sequence.id}))
 
     if created:
         # NOTE(wowkalucky): empty Collection validation


### PR DESCRIPTION
Previously, when learner opens a collection that is already complete, they would get a 500 http error because the SequenceComplete view triggers the dispatch method from the LtiSessionMixin, and the `Lti_strict_forward` and `Lti_update_activity` session variables were not set yet from the LTI launch learner flow.

This PR sets those session variables, even if the LTI launch is going directly to the "sequence is complete" page.