### PR TITLE
Workaround for when session variables are not available for iframe

### DIFF
--- a/bridge_adaptivity/bridge_lti/provider.py
+++ b/bridge_adaptivity/bridge_lti/provider.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.core.cache import cache
-from django.http import Http404, HttpResponseBadRequest
+from django.http import Http404, HttpResponseBadRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
@@ -145,3 +145,8 @@ def learner_flow(request, lti_consumer, tool_provider, collection_id=None):
         return redirect(reverse('module:sequence-complete', kwargs={'pk': sequence.id}))
 
     return redirect(reverse('module:sequence-item', kwargs={'pk': sequence_item_id}))
+
+
+def create_session(request):
+    request.session.cycle_key()
+    return HttpResponse()

--- a/bridge_adaptivity/bridge_lti/provider.py
+++ b/bridge_adaptivity/bridge_lti/provider.py
@@ -148,5 +148,8 @@ def learner_flow(request, lti_consumer, tool_provider, collection_id=None):
 
 
 def create_session(request):
+    """
+    View that creates a new django session
+    """
     request.session.cycle_key()
-    return HttpResponse()
+    return HttpResponse("New user session created")

--- a/bridge_adaptivity/bridge_lti/urls.py
+++ b/bridge_adaptivity/bridge_lti/urls.py
@@ -1,9 +1,10 @@
 from django.conf.urls import url
 
 from bridge_lti.consumer import source_preview
-from bridge_lti.provider import lti_launch
+from bridge_lti.provider import lti_launch, create_session
 
 urlpatterns = [
     url(r'^launch/?(?P<collection_id>\d*)/?$', lti_launch, name='launch'),
     url(r'^source/$', source_preview, name='source-preview'),
+    url(r'^create_session/$', create_session),
 ]

--- a/bridge_adaptivity/module/mixins.py
+++ b/bridge_adaptivity/module/mixins.py
@@ -32,10 +32,12 @@ class LtiSessionMixin(object):
         if not lti_session:
             log.error('Lti session is not found, Request cannot be processed')
             msg = """
-Your browser security settings require an additional step before starting the quiz.
-Please open https://courses.openedx.vpal.io/event and {}/lti/create_session in new browser tabs.
-Then close those tabs, and refresh this page.
-""".format(settings.BRIDGE_HOST)
+                Your browser security settings require an additional step before starting the quiz.
+                Please open https://courses.openedx.vpal.io/event and {}/lti/create_session in new
+                browser tabs. Then close those tabs, and refresh this page. If you continue experiencing
+                problems accessing the quiz, try decreasing your browser's security settings or using a
+                different browser.
+            """.format(settings.BRIDGE_HOST)
             return HttpResponseForbidden(msg)
         elif lti_session != cache.get(sequence_id):
             cache.set(sequence_id, lti_session)

--- a/bridge_adaptivity/module/mixins.py
+++ b/bridge_adaptivity/module/mixins.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseForbidden
 from django.shortcuts import redirect
+from django.conf import settings
 
 log = logging.getLogger(__name__)
 
@@ -30,7 +31,12 @@ class LtiSessionMixin(object):
         sequence_id = request.session.get('Lti_sequence')
         if not lti_session:
             log.error('Lti session is not found, Request cannot be processed')
-            return HttpResponseForbidden("Course content is available only through LTI protocol.")
+            msg = """
+Your browser security settings require an additional step before starting the quiz.
+Please open https://courses.openedx.vpal.io/event and {}/lti/create_session in new browser tabs.
+Then close those tabs, and refresh this page.
+""".format(settings.BRIDGE_HOST)
+            return HttpResponseForbidden(msg)
         elif lti_session != cache.get(sequence_id):
             cache.set(sequence_id, lti_session)
             if request.session['Lti_strict_forward']:

--- a/bridge_adaptivity/module/mixins.py
+++ b/bridge_adaptivity/module/mixins.py
@@ -30,7 +30,7 @@ class LtiSessionMixin(object):
         sequence_id = request.session.get('Lti_sequence')
         if not lti_session:
             log.error('Lti session is not found, Request cannot be processed')
-            return HttpResponseForbidden("Cource content is available only through LTI protocol.")
+            return HttpResponseForbidden("Course content is available only through LTI protocol.")
         elif lti_session != cache.get(sequence_id):
             cache.set(sequence_id, lti_session)
             if request.session['Lti_strict_forward']:


### PR DESCRIPTION
Depending on user's browser settings, the LTI session variables cannot be found - likely due to the problem described in [this link](http://www.mendoweb.be/blog/internet-explorer-safari-third-party-cookie-problem/)

One workaround is to ask the user to visit a page on the iframe host (in this case the bridge). This PR adds a view at /lti/create_session to create a new session and set the cookie manually. After the learner visits that page in a new tab or window, they are able to use the bridge normally.

It also seems like after the learner is able to access the bridge (and get content served from the openedx content source), some javascript from the content source is not able to load, and the submit button in the problem becomes disabled. A similar solution where the learner visits a page on the content source fixes this problem.

This PR adds a message to the learner when the LTI session is not found, that directs them to open pages on the content source and the bridge in new tab/window, close them, then refresh the LMS page in order to start the adaptive quiz.