### PR TITLE
Fix to correctly work with canvas.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ __pycache__/
 
 # local Django logs:
 *.log
-
+.idea/
 ## Secure settings
 secure.py
 secure.config

--- a/bridge_adaptivity/bridge_lti/validator.py
+++ b/bridge_adaptivity/bridge_lti/validator.py
@@ -25,7 +25,9 @@ class SignatureValidator(RequestValidator):
     application-specific requirements.
     """
 
-    def __init__(self):
+    nonce_length = 20, 45
+
+    def  __init__(self):
         super(SignatureValidator, self).__init__()
         self.endpoint = SignatureOnlyEndpoint(self)
         self.lti_consumer = None


### PR DESCRIPTION
Not raise error if nonce lenght is more than 30 symbols. Canvas passed nonce with length 42.
Increase nonce length up to 45 symbols.