### PR TITLE
Ensure cloudwatch tracks correct log file on Elastic Beanstalk config update

### DIFF
--- a/bridge_adaptivity/.ebextensions/cwlogs.config
+++ b/bridge_adaptivity/.ebextensions/cwlogs.config
@@ -1,4 +1,5 @@
 # Configuration of additional log streaming to cloudwatch from containers
+# Uses Elastic Beanstalk Platform Hooks https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/custom-platform-hooks.html
 
 # 01_delete_old_logs: deletes old container log files
 
@@ -32,6 +33,23 @@ files:
       log_group_name = /aws/elasticbeanstalk/`{"Ref": "AWSEBEnvironmentName" }`/var/log/containers/worker
 
   /opt/elasticbeanstalk/hooks/appdeploy/post/99_delete_awslogs_agent_state.sh:
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      #!/bin/bash
+
+      # delete awslogs agent state file so that agent starts monitoring logs
+      # for the most recently created container log file
+
+      AGENTSTATE="/var/lib/awslogs/agent-state"
+      if [ -e $AGENTSTATE ]
+      then
+          sudo rm $AGENTSTATE
+          sudo service awslogs restart
+      fi
+
+  /opt/elasticbeanstalk/hooks/configdeploy/post/99_delete_awslogs_agent_state.sh:
     mode: "000755"
     owner: root
     group: root


### PR DESCRIPTION
Ensure log streaming is not broken by config update (as opposed to app redeploy), when container log to be tracked by awslog agent changes. EB platform hook for config update added.