### PR TITLE
Add tests for send_grade method in all policies

### DIFF
--- a/bridge_adaptivity/bridge_lti/outcomes.py
+++ b/bridge_adaptivity/bridge_lti/outcomes.py
@@ -18,10 +18,10 @@ def update_lms_grades(request=None, sequence=None, user_id=None):
     outcome_request.lis_result_sourcedid = sequence.lis_result_sourcedid
 
     log.debug("Update LMS grades. Used sequence = {} is completed = {}, grading_policy = {}".format(
-        sequence, sequence.completed, sequence.grading_policy
+        sequence, sequence.completed, sequence.group.grading_policy
     ))
 
-    score = sequence.grading_policy.calculate_grade(sequence)
+    score = sequence.group.grading_policy.calculate_grade(sequence)
     outcome_request.post_replace_result(score)
     lms_response = outcome_request.outcome_response
     if lms_response.is_success:

--- a/bridge_adaptivity/module/tests/test_grading_policy.py
+++ b/bridge_adaptivity/module/tests/test_grading_policy.py
@@ -1,9 +1,14 @@
 from ddt import data, ddt, unpack
 from django.test import TestCase
+from django.test.client import RequestFactory
 import mock
 import pytest
 
-from module.models import GRADING_POLICY_NAME_TO_CLS, GradingPolicy, Sequence
+from bridge_lti.models import LtiProvider, OutcomeService
+from module.models import (
+    Activity, BridgeUser, Collection, CollectionGroup, Engine, GRADING_POLICY_NAME_TO_CLS, GradingPolicy, LtiUser,
+    Sequence
+)
 from module.policies.policy_full_credit import FullCreditOnCompleteGradingPolicy
 from module.policies.policy_points_earned import PointsEarnedGradingPolicy
 from module.policies.policy_trials_count import TrialsCountGradingPolicy
@@ -105,3 +110,84 @@ class TestGradingPolicyObject(TestCase):
             grade = GradingPolicyCls(sequence=sequence, policy=policy)._calculate()
             self.assertEqual(grade, er)
             self.assertIsInstance(grade, (float, int))
+
+
+class TestPolicySendGradeMethod(TestCase):
+
+    fixtures = ['gradingpolicy.json', 'engine.json']
+
+    @mock.patch('module.tasks.sync_collection_engines.apply_async')
+    def setUp(self, mock_apply_async):
+        self.rf = RequestFactory()
+        self.user = BridgeUser.objects.create_user(
+            username='test_user',
+            password='test_pass',
+            email='test@test.com'
+        )
+        self.collection = Collection.objects.create(name='testcol1', owner=self.user)
+        self.collection2 = Collection.objects.create(name='testcol2', owner=self.user)
+
+        self.source_launch_url = 'http://test_source_launch_url.com'
+        self.activity = Activity.objects.create(
+            name='testactivity1', collection=self.collection, source_launch_url=self.source_launch_url
+        )
+        self.activity2 = Activity.objects.create(
+            name='testactivity2', collection=self.collection2, source_launch_url=self.source_launch_url
+        )
+        self.lti_provider = LtiProvider.objects.create(
+            consumer_name='test_consumer', consumer_key='test_consumer_key', consumer_secret='test_consumer_secret'
+        )
+        self.lti_user = LtiUser.objects.create(
+            user_id='test_user_id', lti_consumer=self.lti_provider, bridge_user=self.user
+        )
+        self.engine = Engine.objects.get(engine='engine_mock')
+        self.grading_policy = GradingPolicy.objects.get(name='trials_count')
+        self.outcome_service = OutcomeService.objects.create(
+            lis_outcome_service_url='test_url', lms_lti_connection=self.lti_provider
+        )
+
+        self.test_cg = CollectionGroup.objects.create(
+            name='TestColGroup',
+            owner=self.user,
+            engine=self.engine,
+            grading_policy=self.grading_policy
+        )
+        self.test_cg.collections.add(self.collection)
+        self.sequence = Sequence.objects.create(
+            lti_user=self.lti_user,
+            collection=self.collection,
+            group=self.test_cg,
+            outcome_service=self.outcome_service
+        )
+
+    @mock.patch('module.policies.policy_points_earned.update_lms_grades')
+    def test_send_grade_method_policy_points_earned(self, mock_update_lms_grades):
+        """Test policy.send_grade method for policy PointsEarned."""
+        request = self.rf.get('/')
+        policy_model = GradingPolicy.objects.get(name='points_earned')
+        policy = policy_model.policy_instance(
+            sequence=self.sequence,
+            request=request,
+            user_id=self.lti_user.user_id
+        )
+        default_kw = {
+            'sequence': self.sequence,
+            'user_id': self.lti_user.user_id,
+        }
+        policy.send_grade()
+        mock_update_lms_grades.assert_called_with(*(request,), **default_kw)
+
+    @mock.patch('module.policies.base.update_lms_grades')
+    def test_send_grade_method_policy_trials_count(self, mock_update_lms_grades):
+        """Test policy.send_grade method for policies TrialsCount and FullCreditOnComplete."""
+        for policy_model in GradingPolicy.objects.filter(name__in=['trials_count', 'full_credit']):
+            policy = policy_model.policy_instance(
+                sequence=self.sequence,
+                user_id=self.lti_user.user_id
+            )
+            default_kw = {
+                'sequence': self.sequence,
+                'user_id': self.lti_user.user_id,
+            }
+            policy.send_grade()
+            mock_update_lms_grades.assert_called_with(**default_kw)

--- a/bridge_adaptivity/module/tests/test_grading_policy.py
+++ b/bridge_adaptivity/module/tests/test_grading_policy.py
@@ -178,7 +178,7 @@ class TestPolicySendGradeMethod(TestCase):
         mock_update_lms_grades.assert_called_with(*(request,), **default_kw)
 
     @mock.patch('module.policies.base.update_lms_grades')
-    def test_send_grade_method_policy_trials_count(self, mock_update_lms_grades):
+    def test_send_grade_method_policies_trials_count_full_credit(self, mock_update_lms_grades):
         """Test policy.send_grade method for policies TrialsCount and FullCreditOnComplete."""
         for policy_model in GradingPolicy.objects.filter(name__in=['trials_count', 'full_credit']):
             policy = policy_model.policy_instance(

--- a/bridge_adaptivity/module/views.py
+++ b/bridge_adaptivity/module/views.py
@@ -302,7 +302,7 @@ def sequence_item_next(request, pk):
         update_activity = request.session.pop('Lti_update_activity', None)
         if next_sequence_item is None:
             sequence = sequence_item.sequence
-            policy = sequence.grading_policy.policy_instance(
+            policy = sequence.group.grading_policy.policy_instance(
                 sequence=sequence, user_id=sequence.lti_user.user_id,
             )
             policy.send_grade()
@@ -383,7 +383,7 @@ def callback_sequence_item_grade(request):
 
     sequence = sequence_item.sequence
     if sequence.lis_result_sourcedid:
-        policy = sequence.grading_policy.policy_instance(sequence=sequence, request=request, user_id=user_id)
+        policy = sequence.group.grading_policy.policy_instance(sequence=sequence, request=request, user_id=user_id)
         policy.send_grade()
 
     return HttpResponse(xml, content_type="application/xml")


### PR DESCRIPTION
### [PROBLEM]
Described in  ticket AD-90

### [SOLUTION]
Added tests for Policy.send_grade function.


#### [NOTE]
As I found here http://www.voidspace.org.uk/python/mock/patch.html#where-to-patch we should mock no in place where variable or function is defined but in place where it is used.