### PR TITLE
fix(AD-133): If threshold is not required by policy don't show it in group-list view

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,7 @@
+Alex <django.develop@gmail.com>
 Alex Boiko <django.develop@gmail.com>
 Andrew Ang <ang.kunanit@gmail.com>
+Igor Degtiarov <igor.degtiarov@raccoongang.com>
 Igor Degtiarov <igoryok.d@gmail.com>
 Oksana Slusarenko <oksana.slu@gmail.com>
 SdotGlenn <sonnyg.lopez@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,5 @@
-Alex <django.develop@gmail.com>
 Alex Boiko <django.develop@gmail.com>
 Andrew Ang <ang.kunanit@gmail.com>
-Igor Degtiarov <igor.degtiarov@raccoongang.com>
 Igor Degtiarov <igoryok.d@gmail.com>
 Oksana Slusarenko <oksana.slu@gmail.com>
 SdotGlenn <sonnyg.lopez@gmail.com>

--- a/bridge_adaptivity/module/policies/policy_points_earned.py
+++ b/bridge_adaptivity/module/policies/policy_points_earned.py
@@ -7,6 +7,9 @@ class PointsEarnedGradingPolicy(BaseGradingPolicy):
     """Grading policy class calculate grade based upon users earned points."""
 
     public_name = 'Points earned'
+    require = {
+        'threshold': True
+    }
 
     summary_text = """Overall score is the proportion of points earned out of either the total possible points
     earnable, or the threshold Q, whichever is higher."""

--- a/bridge_adaptivity/module/policies/policy_trials_count.py
+++ b/bridge_adaptivity/module/policies/policy_trials_count.py
@@ -3,6 +3,9 @@ from .base import BaseGradingPolicy
 
 class TrialsCountGradingPolicy(BaseGradingPolicy):
     public_name = 'Trials count'
+    require = {
+        'threshold': True
+    }
 
     summary_text = """ Overall score is the number of attempts made divided by the threshold Q, or 1 if the number of
     attempts made is greater than Q."""

--- a/bridge_adaptivity/module/templates/module/collectiongroup_list.html
+++ b/bridge_adaptivity/module/templates/module/collectiongroup_list.html
@@ -29,13 +29,8 @@
           <td style="width:5%; " class="container text-center">{{ group.collections.count }}</td>
           <td class="text-center">{{ group.engine.engine_name }}</td>
           <td class="text-center">{{ group.grading_policy.policy_cls.public_name }}</td>
-<<<<<<< Updated upstream
-          <td class="text-center">{{ group.grading_policy.threshold }}</td>
-          <td>
-=======
           <td class="text-center">{% if group.grading_policy.policy_cls.require.threshold %}{{ group.grading_policy.threshold }}{% endif %}</td>
           <td class="text-right" style="min-width: 90px;">
->>>>>>> Stashed changes
             <div>
               <a class="move-down"
                  href="{% url 'module:group-change' group_slug=group.slug %}?back_url={% url 'module:group-list' %}">

--- a/bridge_adaptivity/module/templates/module/collectiongroup_list.html
+++ b/bridge_adaptivity/module/templates/module/collectiongroup_list.html
@@ -29,8 +29,13 @@
           <td style="width:5%; " class="container text-center">{{ group.collections.count }}</td>
           <td class="text-center">{{ group.engine.engine_name }}</td>
           <td class="text-center">{{ group.grading_policy.policy_cls.public_name }}</td>
+<<<<<<< Updated upstream
           <td class="text-center">{{ group.grading_policy.threshold }}</td>
           <td>
+=======
+          <td class="text-center">{% if group.grading_policy.policy_cls.require.threshold %}{{ group.grading_policy.threshold }}{% endif %}</td>
+          <td class="text-right" style="min-width: 90px;">
+>>>>>>> Stashed changes
             <div>
               <a class="move-down"
                  href="{% url 'module:group-change' group_slug=group.slug %}?back_url={% url 'module:group-list' %}">


### PR DESCRIPTION
### [PROBLEM]
is described in AD-133

### [SOLUTION]
don't show `thereshold` if it's not required by policy