### PR TITLE
Fix evaluating of the error msg for the sync response from VPAL engine

### DIFF
--- a/bridge_adaptivity/module/engines/engine_vpal.py
+++ b/bridge_adaptivity/module/engines/engine_vpal.py
@@ -124,7 +124,7 @@ class EngineVPAL(EngineInterface):
             payload.append(self.fulfill_payload(payload={}, instance_to_parse=activity))
         sync_collection = requests.post(sync_url, json=payload, headers=self.headers)
         return self.check_engine_response(
-            sync_collection.status_code, action='synchronized', obj='collection', name=collection.name, status=201
+            sync_collection.status_code, action='synchronized', obj='collection', name=collection.name
         )
 
     def submit_activity_answer(self, sequence_item):


### PR DESCRIPTION
Currently we expecting response status from the sync request to be 201
and get 200 instead witch is the cause of the error mgs in the logs.
Expected status is exchanged to 200.