### PR TITLE
Upgrade celery version

### DIFF
--- a/bridge_adaptivity/requirements_base.txt
+++ b/bridge_adaptivity/requirements_base.txt
@@ -1,4 +1,4 @@
-celery==4.1.0
+celery==4.1.1
 
 Django==1.11.3
 django-bootstrap3==9.0.0


### PR DESCRIPTION
Celery 4.1.1 adds compatibility for the newer 4.2.0 version of kombu. Unfortunately celery 4.1.0 is broken at the moment because it installs this newer incompatible kombu version by default, which causes the celery worker to fail.

See:
https://github.com/celery/celery/commit/c8ef7ad60b72a194654c58beb04a1d65cd0435ad
https://github.com/celery/kombu/commit/75695205f6e7af8e7e9178e010debc3871b19106

