### PR TITLE
Parent redirection from the iframe

### DIFF
--- a/bridge_adaptivity/bridge_lti/templates/bridge_lti/lti_iframe.html
+++ b/bridge_adaptivity/bridge_lti/templates/bridge_lti/lti_iframe.html
@@ -1,9 +1,0 @@
-<iframe
-    title="${display_name}"
-    class="ltiLaunchFrame"
-    name="ltiFrame-${element_id}"
-    src="${initial_launch_url}"
-    allowfullscreen="true"
-    webkitallowfullscreen="true"
-    mozallowfullscreen="true"
-></iframe>

--- a/bridge_adaptivity/bridge_lti/templates/bridge_lti/ltisource_detail.html
+++ b/bridge_adaptivity/bridge_lti/templates/bridge_lti/ltisource_detail.html
@@ -25,6 +25,7 @@ Content Source:
   allowfullscreen="true"
   webkitallowfullscreen="true"
   mozallowfullscreen="true"
+  sandbox="allow-same-origin allow-forms allow-scripts"
 >
 </iframe>
 

--- a/bridge_adaptivity/module/templates/module/modals/source_modal.html
+++ b/bridge_adaptivity/module/templates/module/modals/source_modal.html
@@ -18,6 +18,7 @@
           allowfullscreen="true"
           webkitallowfullscreen="true"
           mozallowfullscreen="true"
+          sandbox="allow-same-origin allow-forms allow-scripts"
         ></iframe>
       </div>
       <div class="modal-footer">

--- a/bridge_adaptivity/module/templates/module/sequence_item.html
+++ b/bridge_adaptivity/module/templates/module/sequence_item.html
@@ -27,6 +27,7 @@
       allowfullscreen="true"
       webkitallowfullscreen="true"
       mozallowfullscreen="true"
+      sandbox="allow-same-origin allow-forms allow-scripts"
     >
     </iframe>
   </div>


### PR DESCRIPTION
Prevents propagation redirect from the iframe to the top page. 

It is useful when form, that open LTI connection,  return a result with code, that not equal 200. Previously it redirects to some blank page. This fix allows display error locally inside the iframe.