### PR TITLE
Fix issue with the threshold of the points_earned policy is used with 0

### DIFF
--- a/bridge_adaptivity/module/fixtures/gradingpolicy.json
+++ b/bridge_adaptivity/module/fixtures/gradingpolicy.json
@@ -15,7 +15,7 @@
     "fields": {
         "name": "points_earned",
         "public_name": "Points Earned Grading policy",
-        "threshold": 1,
+        "threshold": 0,
         "is_default": false
     }
 },

--- a/bridge_adaptivity/module/policies/policy_points_earned.py
+++ b/bridge_adaptivity/module/policies/policy_points_earned.py
@@ -30,11 +30,14 @@ class PointsEarnedGradingPolicy(BaseGradingPolicy):
         items_result = self.sequence.items.exclude(is_problem=False).aggregate(
             points_earned=Sum('score'), trials_count=Count('score')
         )
-        return items_result['trials_count'], items_result['points_earned']
+        # Note(idegtiarov) With the default 0 threshold and first non-problem activity in the sequence item_result
+        # returns None, None which are not appropriate for the grade calculation method, default values are provided to
+        # fix this issue
+        return (items_result['trials_count'] or 1), (items_result['points_earned'] or 0)
 
     def _calculate(self):
         trials_count, points_earned = self._get_points_earned_trials_count()
-        return round(float(points_earned if points_earned else 0) / max(self.policy.threshold, trials_count), 4)
+        return round(float(points_earned) / max(self.policy.threshold, trials_count), 4)
 
     @classmethod
     def get_form_class(cls):

--- a/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
+++ b/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
@@ -126,8 +126,7 @@
 
   {% url 'module:group-detail' group_slug=group.slug as back_url %}
   {% url "module:add-collection-to-group" group_slug=group.slug as add_collection_url %}
-  {% include "module/modals/link_objects.html" with course=course link_action_url=add_collection_url title='Link
-   collection with group' %}
+  {% include "module/modals/link_objects.html" with course=course link_action_url=add_collection_url title='Link collection with group' %}
 
   </div>
   <div class="col-md-3">


### PR DESCRIPTION
Default 0 value of the threshold in the points_earned policy break grade calculation in the case non-problem activity appears to be the first in the sequence.