### PR TITLE
Update engine api base url for v2

### DIFF
--- a/bridge_adaptivity/module/engines/engine_vpal.py
+++ b/bridge_adaptivity/module/engines/engine_vpal.py
@@ -50,7 +50,7 @@ class EngineVPAL(EngineInterface):
 
     def __init__(self, **kwargs):
         self.host = kwargs.get('HOST')
-        self.api_url = 'engine/api/'
+        self.api_url = 'api/v2/'
         self.base_url = urllib.parse.urljoin(self.host, self.api_url)
         self.activity_url = urllib.parse.urljoin(self.base_url, "activity")
         token = kwargs.get('TOKEN')


### PR DESCRIPTION
The recent engine API changes (e.g. learner dict representation, collection slug as id) will be available on the engine under a new api base path, `{host}/api/v2/`.