### PR TITLE
Update 403 template with browser suggestion

### DIFF
--- a/bridge_adaptivity/templates/403.html
+++ b/bridge_adaptivity/templates/403.html
@@ -6,5 +6,6 @@
 </head>
 <body>
 <h1>Something went wrong.... (403).</h1>
+<p>If you are using Safari, please try again using either the Chrome or Firefox browsers. Sorry for the inconvenience!</p>
 </body>
 </html>


### PR DESCRIPTION
When LTI session is not found (often using Safari browser, due to third-party cookie blocking), the 403 template is returned, so a suggestion to use Chrome/Firefox is added.