### PR TITLE
Pass user_id lti parameter to engine

### DIFF
--- a/bridge_adaptivity/module/engines/engine_vpal.py
+++ b/bridge_adaptivity/module/engines/engine_vpal.py
@@ -111,7 +111,7 @@ class EngineVPAL(EngineInterface):
             payload.update(metadata if add_metadata else {})  # payload is updated with the lti parameters
         payload.update({
             "learner": {
-                'user_id': sequence.lti_user.id,
+                'user_id': sequence.lti_user.user_id,
                 'tool_consumer_instance_guid': (
                     tool_consumer_instance_guid or sequence.lti_user.lti_consumer.consumer_name
                 ),

--- a/bridge_adaptivity/module/tests/test_vpal_engine.py
+++ b/bridge_adaptivity/module/tests/test_vpal_engine.py
@@ -93,7 +93,7 @@ class TestVPALEngine(TestCase):
         )
         expected_payload = {
             "learner": {
-                'user_id': self.sequence.lti_user.id,
+                'user_id': self.sequence.lti_user.user_id,
                 # NOTE(idegtiarov) `tool_consumer_instance_guid` is equal to the LTIProvider.consumer_name if it is not
                 # add to the Engine.lti_parameters or not found in received lti_launch parameters.
                 'tool_consumer_instance_guid': self.lti_consumer.consumer_name,
@@ -139,7 +139,7 @@ class TestVPALEngine(TestCase):
         )
         expected_payload = {
             "learner": {
-                'user_id': self.sequence.lti_user.id,
+                'user_id': self.sequence.lti_user.user_id,
                 'tool_consumer_instance_guid': expected_tool_consumer_instance_guid,
             },
             "collection": self.sequence.collection.slug,
@@ -176,7 +176,7 @@ class TestVPALEngine(TestCase):
         )
         expected_payload = {
             "learner": {
-                'user_id': self.sequence.lti_user.id,
+                'user_id': self.sequence.lti_user.user_id,
                 'tool_consumer_instance_guid': self.lti_consumer.consumer_name,
             },
             "collection": self.sequence.collection.slug,


### PR DESCRIPTION
Pass the LTI user_id parameter instead of the internal key for the lti_user model instance to the VPAL engine during API calls.