### PR TITLE
Feature [Default policy values]

### DIFF
--- a/bridge_adaptivity/module/forms.py
+++ b/bridge_adaptivity/module/forms.py
@@ -95,11 +95,15 @@ class ThresholdGradingPolicyForm(ModelForm):
     def clean(self):
         super().clean()
         policy_name, params = self.cleaned_data.get('name'), self.cleaned_data.get('params')
-        required_params = GRADING_POLICY_NAME_TO_CLS.get(policy_name).require.get('params', [])
+        required_params = GRADING_POLICY_NAME_TO_CLS.get(policy_name).require.get('params')
         if required_params:
-            for param in required_params:
-                if not params or param not in params:
-                    raise forms.ValidationError("Not all required parameters are set correctly.")
+            if params is None:
+                params = self.cleaned_data['params'] = {}
+            for param, default in required_params.items():
+                # TODO(idegtiarov) Second condition is the hardcoded `threshold` parameter validation.
+                # It should be rewritten when some new parameter appears.
+                if param not in params or params[param] < 1:
+                    params[param] = default
         return self.cleaned_data
 
 

--- a/bridge_adaptivity/module/policies/base.py
+++ b/bridge_adaptivity/module/policies/base.py
@@ -6,7 +6,8 @@ from bridge_lti.outcomes import update_lms_grades
 
 
 class BaseGradingPolicy(object, metaclass=ABCMeta):
-    """Base grading policy class defines methods and variables of grading policy.
+    """
+    Base grading policy class defines methods and variables of grading policy.
 
     >>> gp =  BaseGradingPolicy(sequence=1, policy=2, b=3)
     >>> gp.sequence
@@ -24,6 +25,9 @@ class BaseGradingPolicy(object, metaclass=ABCMeta):
     """
 
     public_name = 'Grading Policy'
+
+    # NOTE(idegtiarov) require dict contains parameters required for the policy for example
+    # params - in the required dict is a dict with key - required parameter and value - default magnitude
     require = {}
 
     """Next 2 fields (summary_text, detail_text) should be defined in inherited classes

--- a/bridge_adaptivity/module/policies/policy_points_earned.py
+++ b/bridge_adaptivity/module/policies/policy_points_earned.py
@@ -8,8 +8,9 @@ class PointsEarnedGradingPolicy(BaseGradingPolicy):
     """Grading policy class calculate grade based upon users earned points."""
 
     public_name = 'Points earned'
+
     require = {
-        'params': ['threshold'],
+        'params': {'threshold': 1},
     }
 
     summary_text = """Overall score is the proportion of points earned out of either the total possible points

--- a/bridge_adaptivity/module/policies/policy_trials_count.py
+++ b/bridge_adaptivity/module/policies/policy_trials_count.py
@@ -4,7 +4,7 @@ from .base import BaseGradingPolicy
 class TrialsCountGradingPolicy(BaseGradingPolicy):
     public_name = 'Trials count'
     require = {
-        'params': ['threshold'],
+        'params': {'threshold': 1},
     }
 
     summary_text = """ Overall score is the number of attempts made divided by the threshold Q, or 1 if the number of

--- a/bridge_adaptivity/module/tests/test_forms.py
+++ b/bridge_adaptivity/module/tests/test_forms.py
@@ -1,0 +1,39 @@
+from ddt import data, ddt, unpack
+from django.test import TestCase
+
+from module.forms import ThresholdGradingPolicyForm
+
+
+@ddt
+class ThresholdGradingPolicyFormTest(TestCase):
+    """
+    Test ThresholdGradingPolicyForm for the `trials_count` and `points_earned` policies.
+    """
+
+    @data('trials_count', 'points_earned')
+    def test_grading_policy_params_default_values(self, policy_name):
+        payload = {
+            'name': policy_name,
+        }
+        policy = ThresholdGradingPolicyForm(payload)
+        self.assertTrue(policy.is_valid())
+        # NOTE(idegtiarov) currently `threshold` is the only policy's parameter with the default value,
+        # which is equal to 1
+        self.assertEqual(policy.clean()['params']['threshold'], 1)
+
+    @unpack
+    @data(
+        {'policy_name': 'trials_count', 'threshold': -10},
+        {'policy_name': 'trials_count', 'threshold': 0},
+        {'policy_name': 'points_earned', 'threshold': -10},
+        {'policy_name': 'points_earned', 'threshold': 0},
+    )
+    def test_grading_policy_parameter_negative_threshold_validation(self, policy_name, threshold):
+        payload = {
+            'name': policy_name,
+            'params': {'threshold': threshold}
+        }
+        policy = ThresholdGradingPolicyForm(payload)
+        self.assertTrue(policy.is_valid())
+        # NOTE(idegtiarov) `threshold` validation ignore not positive value (<= 0) and exchange it with the default one.
+        self.assertEqual(policy.clean()['params']['threshold'], 1)


### PR DESCRIPTION
Add default values to the required parameters if they aren't set properly.

Add threshold validation for ignoring not positive int values (<= 0) and exchange it with the default policy's threshold value.