### PR TITLE
Set `SESSION_COOKIE_SAMESITE` to None to revert session behaviour.

### DIFF
--- a/bridge_adaptivity/config/settings/base.py
+++ b/bridge_adaptivity/config/settings/base.py
@@ -152,6 +152,10 @@ PROBLEM_ACTIVITY_TYPES = (
     'problem',
 )
 
+# NOTE(idegtiarov) `SESSION_COOKIE_SAMESITE` was added in Django 2.1 and has broken current LTI session flow.
+#    The parameter is set to None to revert the previous behavior.
+SESSION_COOKIE_SAMESITE = None
+
 # Django Rest Framework
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (


### PR DESCRIPTION
`SESSION_COOKIE_SAMESITE` was added in Django 2.1 and has broken current LTI session flow.
The parameter is set to None to revert the previous behavior.