### PR TITLE
Added tests for checking: session variable, csrf token, and correct LTI request

### DIFF
--- a/bridge_adaptivity/bridge_lti/tests/test_provider.py
+++ b/bridge_adaptivity/bridge_lti/tests/test_provider.py
@@ -145,14 +145,14 @@ class ProviderTest(BridgeTestCase):
         consumer_prams = {
             'consumer_key': self.lti_provider.consumer_key,
             'consumer_secret': self.lti_provider.consumer_secret,
-            'launch_url': 'http://{}'.format(settings.BRIDGE_HOST) + reverse(
+            'launch_url': f"http://{settings.BRIDGE_HOST}" + reverse(
                 'lti:launch', kwargs={'collection_slug': self.collection1.slug, 'group_slug': str(self.test_cg.slug)}
             ),
             'params': {
                 # Required parameters
                 'lti_message_type': 'basic-lti-launch-request',
                 'lti_version': 'LTI-1p0',
-                # It's random value. It's normal for test.
+                # The random value is used for the test purpose
                 'resource_link_id': '-523523423423423423423423423',
                 # Recommended parameters
                 'user_id': 'bridge_user',
@@ -179,6 +179,7 @@ class ProviderTest(BridgeTestCase):
         """
         with override_settings(CSRF_COOKIE_SAMESITE=csrf_cookie_samsite):
             csrf_client = Client(enforce_csrf_checks=True)
+            csrf_cookie_expected_result = csrf_cookie_samsite or ''
             # Get csrf_token
             response_get = csrf_client.get(reverse('login'))
             cookies_item = {}
@@ -186,9 +187,7 @@ class ProviderTest(BridgeTestCase):
                 cookies_item[key] = value
             csrftoken = cookies_item['csrftoken']
             csrftoken_id, samesite = csrftoken.coded_value, csrftoken.get('samesite')
-            # csrf_cookie_samsite or ''
-            # because '' is default value for 'samesite' and None is default for 'CSRF_COOKIE_SAMESITE'
-            self.assertEqual(samesite, csrf_cookie_samsite or '')
+            self.assertEqual(samesite, csrf_cookie_expected_result)
 
             response_status = 200
             if samesite:

--- a/bridge_adaptivity/bridge_lti/tests/test_provider.py
+++ b/bridge_adaptivity/bridge_lti/tests/test_provider.py
@@ -2,8 +2,9 @@ import logging
 
 from ddt import data, ddt
 from django.contrib.sessions.middleware import SessionMiddleware
+
 from django.http import HttpResponse
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from lti.contrib.django import DjangoToolProvider
 import mock
@@ -13,6 +14,7 @@ from bridge_lti.provider import learner_flow
 from module.models import Sequence
 from module.tests.test_views import BridgeTestCase
 
+from django.test.client import Client
 log = logging.getLogger(__name__)
 
 
@@ -125,3 +127,121 @@ class ProviderTest(BridgeTestCase):
 
         # Ensure that only one LTI user was created.
         self.assertEqual(LtiUser.objects.all().count(), count_of_lti_users + 1)
+
+    @mock.patch('bridge_lti.provider.instructor_flow')
+    @mock.patch('bridge_lti.provider.learner_flow')
+    @data('Instructor',)
+    def test_lti_launch_correct_query(
+        self, role,  mock_learner_flow, mock_instructor_flow,
+    ):
+        # Checking only list of property or use validator?
+        # @mock.patch('bridge_lti.validator.SignatureValidator.validate_access_token')
+        # @mock.patch('bridge_lti.validator.SignatureValidator.validate_timestamp_and_nonce')
+        # @data('Instructor', 'Administrator', 'Learner', 'Student')
+        
+        mock_instructor_flow.return_value = HttpResponse(status=200)
+        mock_learner_flow.return_value = HttpResponse(status=200)
+
+        # 'collection_slug': self.collection1.slug,
+        # 'group_slug': str(self.test_cg.slug),
+        
+        consumer_prams = {
+            'consumer_key': self.lti_provider.consumer_key,
+            'consumer_secret': self.lti_provider.consumer_secret,
+            'launch_url': 'http://localhost' + reverse(
+                'lti:launch',
+                kwargs={
+                    'collection_slug': self.collection1.slug,
+                    'group_slug': str(self.test_cg.slug),
+
+                }),
+            'params': {
+                # Required parameters
+                'lti_message_type': 'basic-lti-launch-request',
+                'lti_version': 'LTI-1p0',
+                'resource_link_id': '-881cb88b68e34194959b3038cd5f918f',
+                # Recommended parameters
+                'user_id': 'bridge_user',
+                'roles': role,
+                'oauth_callback': 'about:blank',
+                'context_id': 'bridge_collection'
+            },
+        }
+        from lti import ToolConfig, ToolConsumer
+        consumer = ToolConsumer(**consumer_prams)
+        data = consumer.generate_launch_data()
+        response = self.client.post(
+            consumer.launch_url,
+            data=data,
+            headers={
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }
+
+        )
+        # mock_instructor_flow.assert_called_once_with(mock.ANY, collection_slug=mock_collection_slug)
+        # mock_learner_flow.assert_not_called()
+
+    @data('Lax', None)
+    def test_lti_launch_csrf_token(
+        self, csrf_cookie_samsite,
+    ):
+        with override_settings(CSRF_COOKIE_SAMESITE=csrf_cookie_samsite):
+            csrf_client = Client(enforce_csrf_checks=True)
+            csrf_client.cookies.clear()
+            response_get = csrf_client.get(reverse('login'))
+            cookies_item = {}
+            for key, value in response_get.cookies.items():
+                cookies_item[key] = value
+            csrftoken = cookies_item['csrftoken']
+            csrftoken_id, samesite = csrftoken.coded_value, csrftoken.get('samesite', None)
+            
+            self.assertEqual(samesite, csrf_cookie_samsite or '')
+            
+            response_status = 302
+            if samesite:
+                csrf_client.cookies.clear()
+                response_status = 403
+            response = csrf_client.post(
+                reverse(
+                    'login'
+                ),
+                data={
+                    'username': 'test',
+                    'password': "test",
+                    'csrfmiddlewaretoken': csrftoken_id
+                }
+            )
+            self.assertEqual(response.status_code, response_status)
+
+    @mock.patch('bridge_lti.provider.get_tool_provider_for_lti')
+    @mock.patch('bridge_lti.provider.learner_flow')
+    @mock.patch('module.views.SequenceComplete.get_object')
+    @data('lax', None)
+    def test_lti_launch_session_check(
+        self, session_cookie_samsite, mock_module_get_object, mock_learner_flow, mock_get_tool_provider_for_lti
+    ):
+        mock_get_tool_provider_for_lti.return_value = True
+        mock_learner_flow.return_value = HttpResponse(status=200)
+        mock_module_get_object.__name__ = 'get_object'
+        mock_collection_slug = '3'
+        with override_settings(SESSION_COOKIE_SAMESITE=session_cookie_samsite):
+            self.client.post(
+                reverse(
+                    'lti:launch',
+                    kwargs={
+                        'collection_slug': mock_collection_slug,
+                        'group_slug': 'group-slug',
+                    }
+                ),
+                data={
+                    'oauth_nonce': 'oauth_nonce',
+                    'oauth_consumer_key': self.lti_provider.consumer_key,
+                }
+            )
+            response_status = 200
+            if session_cookie_samsite:
+                # delete session. It's the same if we send get query without sessionid and cookies.
+                self.client.session.flush()
+                response_status = 403
+            response = self.client.get(reverse('module:sequence-complete', kwargs={'pk': mock_collection_slug}))
+            self.assertEqual(response.status_code, response_status)

--- a/bridge_adaptivity/bridge_lti/tests/test_provider.py
+++ b/bridge_adaptivity/bridge_lti/tests/test_provider.py
@@ -2,10 +2,11 @@ import logging
 
 from ddt import data, ddt
 from django.contrib.sessions.middleware import SessionMiddleware
-
 from django.http import HttpResponse
-from django.test import RequestFactory, override_settings
+from django.test import override_settings, RequestFactory
+from django.test.client import Client
 from django.urls import reverse
+from lti import ToolConsumer
 from lti.contrib.django import DjangoToolProvider
 import mock
 
@@ -14,8 +15,6 @@ from bridge_lti.provider import learner_flow
 from module.models import Sequence
 from module.tests.test_views import BridgeTestCase
 
-from django.test.client import Client
-from lti import ToolConsumer
 log = logging.getLogger(__name__)
 
 
@@ -132,12 +131,16 @@ class ProviderTest(BridgeTestCase):
     @mock.patch('bridge_lti.provider.instructor_flow')
     @mock.patch('bridge_lti.provider.learner_flow')
     @data('Instructor', 'Administrator', 'Learner', 'Student')
-    def test_lti_launch_correct_query(
-        self, role,  mock_learner_flow, mock_instructor_flow,
-    ):
+    def test_lti_launch_correct_query(self, role, mock_learner_flow, mock_instructor_flow):
+        """
+        Test for checking LTI query.
+
+        :param role: String identifier for role in platform
+        :param mock_learner_flow: mocking method of bridge_lti.provider.learner_flow
+        :param mock_instructor_flow: mocking method of bridge_lti.provider.instructor_flow
+        """
         mock_instructor_flow.return_value = HttpResponse(status=200)
         mock_learner_flow.return_value = HttpResponse(status=200)
-        
         consumer_prams = {
             'consumer_key': self.lti_provider.consumer_key,
             'consumer_secret': self.lti_provider.consumer_secret,
@@ -148,6 +151,7 @@ class ProviderTest(BridgeTestCase):
                 # Required parameters
                 'lti_message_type': 'basic-lti-launch-request',
                 'lti_version': 'LTI-1p0',
+                # It's random value. It's normal for test.
                 'resource_link_id': '-523523423423423423423423423',
                 # Recommended parameters
                 'user_id': 'bridge_user',
@@ -166,30 +170,34 @@ class ProviderTest(BridgeTestCase):
         self.assertEqual(response.status_code, 200)
 
     @data('Lax', None)
-    def test_lti_launch_csrf_token(
-        self, csrf_cookie_samsite,
-    ):
+    def test_lti_launch_csrf_token(self, csrf_cookie_samsite):
+        """
+        Test for checking csrf token in post request.
+
+        :param csrf_cookie_samsite: value for CSRF_COOKIE_SAMESITE variable
+        """
         with override_settings(CSRF_COOKIE_SAMESITE=csrf_cookie_samsite):
             csrf_client = Client(enforce_csrf_checks=True)
-            csrf_client.cookies.clear()
+            # Get csrf_token
             response_get = csrf_client.get(reverse('login'))
             cookies_item = {}
             for key, value in response_get.cookies.items():
                 cookies_item[key] = value
             csrftoken = cookies_item['csrftoken']
-            csrftoken_id, samesite = csrftoken.coded_value, csrftoken.get('samesite', None)
-            
+            csrftoken_id, samesite = csrftoken.coded_value, csrftoken.get('samesite')
+            # csrf_cookie_samsite or ''
+            # because '' is default value for 'samesite' and None is default for 'CSRF_COOKIE_SAMESITE'
             self.assertEqual(samesite, csrf_cookie_samsite or '')
-            
-            response_status = 302
+
+            response_status = 200
             if samesite:
                 csrf_client.cookies.clear()
                 response_status = 403
             response = csrf_client.post(
                 reverse('login'),
                 data={
-                    'username': 'test',
-                    'password': "test",
+                    'username': self.user.username,
+                    'password': self.user.password,
                     'csrfmiddlewaretoken': csrftoken_id
                 }
             )
@@ -198,23 +206,35 @@ class ProviderTest(BridgeTestCase):
     @mock.patch('bridge_lti.provider.get_tool_provider_for_lti')
     @mock.patch('bridge_lti.provider.learner_flow')
     @mock.patch('module.views.SequenceComplete.get_object')
-    @data('lax', None)
+    @data('Lax', None)
     def test_lti_launch_session_check(
         self, session_cookie_samsite, mock_module_get_object, mock_learner_flow, mock_get_tool_provider_for_lti
     ):
+        """
+        Test for checking session variables in request.
+
+        Session's variables need to be in each query.
+        :param session_cookie_samsite: value for SESSION_COOKIE_SAMESITE variable
+        :param mock_module_get_object: mocking method of module.views.Sequence Complete.get_object
+        :param mock_learner_flow: mocking method of bridge_lti.provider.learner_flow
+        :param mock_get_tool_provider_for_lti: mocking method of bridge_lti.provider.get_tool_provider_for_lti
+        """
         mock_get_tool_provider_for_lti.return_value = True
         mock_learner_flow.return_value = HttpResponse(status=200)
         mock_module_get_object.__name__ = 'get_object'
-        mock_collection_slug = '3'
         with override_settings(SESSION_COOKIE_SAMESITE=session_cookie_samsite):
+            # Get session variables
             self.client.post(
-                reverse('lti:launch', kwargs={'collection_slug': mock_collection_slug, 'group_slug': 'group-slug'}),
+                reverse(
+                    'lti:launch',
+                    kwargs={'collection_slug': self.collection1.slug, 'group_slug': str(self.test_cg.slug)}
+                ),
                 data={'oauth_nonce': 'oauth_nonce', 'oauth_consumer_key': self.lti_provider.consumer_key}
             )
             response_status = 200
             if session_cookie_samsite:
-                # delete session. It's the same if we send get query without sessionid and cookies.
+                # delete session. It's the same if we send get query without sessionid.
                 self.client.session.flush()
                 response_status = 403
-            response = self.client.get(reverse('module:sequence-complete', kwargs={'pk': mock_collection_slug}))
+            response = self.client.get(reverse('module:sequence-complete', kwargs={'pk': self.collection1.pk}))
             self.assertEqual(response.status_code, response_status)

--- a/bridge_adaptivity/bridge_lti/tests/test_provider.py
+++ b/bridge_adaptivity/bridge_lti/tests/test_provider.py
@@ -1,6 +1,7 @@
 import logging
 
 from ddt import data, ddt
+from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.test import override_settings, RequestFactory
@@ -144,7 +145,7 @@ class ProviderTest(BridgeTestCase):
         consumer_prams = {
             'consumer_key': self.lti_provider.consumer_key,
             'consumer_secret': self.lti_provider.consumer_secret,
-            'launch_url': 'http://localhost' + reverse(
+            'launch_url': 'http://{}'.format(settings.BRIDGE_HOST) + reverse(
                 'lti:launch', kwargs={'collection_slug': self.collection1.slug, 'group_slug': str(self.test_cg.slug)}
             ),
             'params': {
@@ -163,7 +164,7 @@ class ProviderTest(BridgeTestCase):
         consumer = ToolConsumer(**consumer_prams)
         response = self.client.post(
             consumer.launch_url,
-            HTTP_HOST='localhost',
+            HTTP_HOST=settings.BRIDGE_HOST,
             data=consumer.generate_launch_data(),
             headers={'Content-Type': 'application/x-www-form-urlencoded'}
         )

--- a/bridge_adaptivity/config/settings/secure_example.py
+++ b/bridge_adaptivity/config/settings/secure_example.py
@@ -8,7 +8,7 @@ Should be ignored by VCS (Git).
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = 'xf!mz_(en(p=tcp$-4%lse$9f55e+q)10rcve@bxhzcnrtv)hj-key'
 STATIC_ROOT = 'static/'
-ALLOWED_HOSTS = []  # add bridge host in production
+ALLOWED_HOSTS = ['localhost']  # add bridge host in production
 BRIDGE_HOST = 'localhost:8008'
 
 # related to `bridge_adaptivity/envs/pg.env`

--- a/bridge_adaptivity/module/mixins/views.py
+++ b/bridge_adaptivity/module/mixins/views.py
@@ -38,7 +38,7 @@ class LtiSessionMixin(object):
             raise PermissionDenied("Course content is available only through LTI protocol.")
         elif lti_session != cache.get(sequence_id):
             cache.set(sequence_id, lti_session)
-            if request.session['Lti_strict_forward']:
+            if request.session.get('Lti_strict_forward'):
                 request.session['Lti_update_activity'] = True
                 log.debug("[StrictForward] Session is changed, activity update could be required: {}".format(
                     request.session['Lti_update_activity'])

--- a/bridge_adaptivity/module/tests/test_views.py
+++ b/bridge_adaptivity/module/tests/test_views.py
@@ -5,8 +5,8 @@ import uuid
 from django.test import TestCase
 from django.urls.base import reverse
 from mock import patch
-
 from oauthlib.common import generate_token
+
 from bridge_lti.models import LtiConsumer, LtiProvider
 from module.mixins.views import GroupEditFormMixin
 from module.models import (
@@ -74,6 +74,8 @@ class BridgeTestCase(TestCase):
         # LtiProvider
         self.lti_provider = LtiProvider.objects.create(
             consumer_name='consumer_name',
+            # This method generates a valid consumer_key.
+            # The valid consumer_key is used in the test for checking LTI query.
             consumer_key=generate_token(length=25),
             consumer_secret='consumer_secret',
             expiration_date=datetime.datetime.today() + datetime.timedelta(days=1),

--- a/bridge_adaptivity/module/tests/test_views.py
+++ b/bridge_adaptivity/module/tests/test_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.urls.base import reverse
 from mock import patch
 
+from oauthlib.common import generate_token
 from bridge_lti.models import LtiConsumer, LtiProvider
 from module.mixins.views import GroupEditFormMixin
 from module.models import (
@@ -73,7 +74,7 @@ class BridgeTestCase(TestCase):
         # LtiProvider
         self.lti_provider = LtiProvider.objects.create(
             consumer_name='consumer_name',
-            consumer_key='consumer_key',
+            consumer_key=generate_token(length=25),
             consumer_secret='consumer_secret',
             expiration_date=datetime.datetime.today() + datetime.timedelta(days=1),
             lms_metadata='lms_metadata'


### PR DESCRIPTION
Description: 
Add tests that testing provider:
- Checking the session variable in the request
- Checking the csrf_token variable in the POST request from FORM
- Checking the LTI request 

Task: 
Jira - https://vpalresearch.atlassian.net/browse/AD-101
Youtrack - https://youtrack.raccoongang.com/issue/ALOSI-4