### PR TITLE
Add drag and drop to collection detail page

### DIFF
--- a/bridge_adaptivity/module/static/module/js/base_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/base_drag_drop.js
@@ -1,0 +1,83 @@
+// Utility function which exchange element's index
+function updateElement(element, index) {
+    element.dataset.index = index;
+    return element;
+}
+
+
+function before_add_element(element, index) {
+    //Write script that will run before add ellement to table
+}
+
+function is_forbidden_to_chage(dataset, data) {
+    return false
+}
+
+function get_ordering_elements_list(moveIndex, elIndex) {
+    let collectionList = $('tr.droppable'),
+        shift = 0,
+        newCollectionList = [];
+    $.each(collectionList, function (index, _) {
+            if (index == elIndex) {
+                newCollectionList[index] = updateElement(collectionList[moveIndex], index);
+                shift = moveIndex < elIndex ? 0 : -1;
+            } else if (index == moveIndex && moveIndex < elIndex) {
+                shift = 1;
+                newCollectionList[index] = updateElement(collectionList[index + shift], index);
+            } else if (index == moveIndex && moveIndex > elIndex) {
+                newCollectionList[index] = updateElement(collectionList[index + shift], index);
+                shift = 0;
+            } else {
+                newCollectionList[index] = updateElement(collectionList[index + shift], index);
+            }
+        });
+    collectionList.remove();
+    return newCollectionList
+}
+
+// Function processing drop of the element
+function drop_handler(event, el) {
+    event.preventDefault();
+    let data = event.dataTransfer.getData("text/plain").split(','),
+        elIndex = el.dataset.index, // index of the target element
+        moveUrl = data[1], // move URL of the dropped element
+        moveIndex = data[0], // initial index of the dropped element
+    is_forbidden_extra_cheack = is_forbidden_to_chage(el.dataset, data)
+    if (moveIndex === elIndex || is_forbidden_extra_cheack) {
+        console.log("Item doesn't change the order");
+    } else {
+        console.log("Trying change Item " + moveIndex + " order to " + elIndex);
+        moveUrl = moveUrl.replace("?", elIndex + "?");
+        orderingElementsList = get_ordering_elements_list(moveIndex, elIndex)
+        $.each(orderingElementsList, function (index, element) {
+            before_add_element(element, index)
+            $("table").append(element);
+        });
+        $.ajax({
+            type: "GET",
+            url: moveUrl,
+            success: responseData => {
+                console.log("Collection's changed order is persisted to the backend.");
+            },
+            error: responseData => console.log("Cannot change collections order " + responseData)
+        });
+    }
+}
+
+function dragover_handler(event, drop_effect="move") {
+    event.preventDefault();
+    // Set the dropEffect to move
+    event.dataTransfer.dropEffect = drop_effect;
+}
+
+
+function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
+    // Function that work with event.dataTransfer and event_target_dataset. Example:
+    //  event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
+}
+
+// Handler function of the drag start process
+function dragstart_handler(event, drop_effect="move") {
+    set_event_data_transfer_from_event_target_dataset(event.dataTransfer, event.target.dataset)
+    event.dropEffect = drop_effect;
+}

--- a/bridge_adaptivity/module/static/module/js/base_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/base_drag_drop.js
@@ -73,7 +73,7 @@ function dragover_handler(event, drop_effect="move") {
 
 function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
     // Function that work with event.dataTransfer and event_target_dataset. Example:
-    //  event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
+    //  event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
 }
 
 // Handler function of the drag start process

--- a/bridge_adaptivity/module/static/module/js/base_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/base_drag_drop.js
@@ -6,7 +6,7 @@ function updateElement(element, index) {
 
 
 function before_add_element(element, index) {
-    //Write script that will run before add ellement to table
+    // Write a script that will be run before adding an ellement to the table
 }
 
 function is_forbidden_to_chage(dataset, data) {
@@ -73,7 +73,7 @@ function dragover_handler(event, drop_effect="move") {
 
 function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
     // Function that work with event.dataTransfer and event_target_dataset. Example:
-    //  event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
+    // event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
 }
 
 // Handler function of the drag start process

--- a/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
@@ -1,0 +1,65 @@
+// Utility function which exchange element's index
+function updateElement(element, index) {
+    element.dataset.index = index;
+    return element;
+}
+
+// Function processing drop of the element
+function drop_handler(event, el) {
+    event.preventDefault();
+    let data = event.dataTransfer.getData("text/plain").split(','),
+        elIndex = el.dataset.index, // index of the target element
+        elAtype = el.dataset.atype, // atype of the target element
+        moveUrl = data[1], // move URL of the dropped element
+        moveIndex = data[0], // initial index of the dropped element
+        moveAtype = data[2]; // atype of the dropped element
+    if (moveIndex === elIndex || moveAtype !== elAtype || elAtype === "G" || moveAtype === "G" ) {
+        console.log("Item doesn't change the order");
+    } else {
+        console.log("Trying change Item " + moveIndex + " order to " + elIndex);
+        moveUrl = moveUrl.replace("?", elIndex + "?");
+        let collectionList = $('tr.droppable'),
+            shift = 0,
+            newCollectionList = [];
+        // Update elements order on the frontend
+        $.each(collectionList, function (index, _) {
+            if (index == elIndex) {
+                newCollectionList[index] = updateElement(collectionList[moveIndex], index);
+                shift = moveIndex < elIndex ? 0 : -1;
+            } else if (index == moveIndex && moveIndex < elIndex) {
+                shift = 1;
+                newCollectionList[index] = updateElement(collectionList[index + shift], index);
+            } else if (index == moveIndex && moveIndex > elIndex) {
+                newCollectionList[index] = updateElement(collectionList[index + shift], index);
+                shift = 0;
+            } else {
+                newCollectionList[index] = updateElement(collectionList[index + shift], index);
+            }
+        });
+        collectionList.remove();
+        $.each(newCollectionList, function (index, element) {
+            $("table").append(element);
+        });
+        $.ajax({
+            type: "GET",
+            url: moveUrl,
+            success: responseData => {
+                console.log("Collection's changed order is persisted to the backend.");
+            },
+            error: responseData => console.log("Cannot change collections order " + responseData)
+        });
+    }
+}
+
+// Handler function of the drag over process
+function dragover_handler(event) {
+    event.preventDefault();
+    // Set the dropEffect to move
+    event.dataTransfer.dropEffect = "move";
+}
+
+// Handler function of the drag start process
+function dragstart_handler(event) {
+    event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url + ',' + event.target.dataset.atype);
+    event.dropEffect = "move";
+}

--- a/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
@@ -1,7 +1,7 @@
 // include base_drag_drop.js before this script
 
 function before_add_element(element, index) {
-    //Write script that will run before add ellement to table
+    // Write a script that will be run before adding an ellement to the table
     label = element.getElementsByClassName("label");
     if (label.length !== 0){
         labelItem = label.item(0);
@@ -20,6 +20,6 @@ function is_forbidden_to_chage(dataset, data) {
 
 function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
     // Function that work with event.dataTransfer and event_target_dataset. Example:
-    //  event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
+    // event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
     event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url + ',' + event_target_dataset.atype);
 }

--- a/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
@@ -20,6 +20,6 @@ function is_forbidden_to_chage(dataset, data) {
 
 function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
     // Function that work with event.dataTransfer and event_target_dataset. Example:
-    //  event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
+    //  event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
     event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url + ',' + event_target_dataset.atype);
 }

--- a/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
@@ -1,65 +1,25 @@
-// Utility function which exchange element's index
-function updateElement(element, index) {
-    element.dataset.index = index;
-    return element;
-}
+// include base_drag_drop.js before this script
 
-// Function processing drop of the element
-function drop_handler(event, el) {
-    event.preventDefault();
-    let data = event.dataTransfer.getData("text/plain").split(','),
-        elIndex = el.dataset.index, // index of the target element
-        elAtype = el.dataset.atype, // atype of the target element
-        moveUrl = data[1], // move URL of the dropped element
-        moveIndex = data[0], // initial index of the dropped element
-        moveAtype = data[2]; // atype of the dropped element
-    if (moveIndex === elIndex || moveAtype !== elAtype || elAtype === "G" || moveAtype === "G" ) {
-        console.log("Item doesn't change the order");
-    } else {
-        console.log("Trying change Item " + moveIndex + " order to " + elIndex);
-        moveUrl = moveUrl.replace("?", elIndex + "?");
-        let collectionList = $('tr.droppable'),
-            shift = 0,
-            newCollectionList = [];
-        // Update elements order on the frontend
-        $.each(collectionList, function (index, _) {
-            if (index == elIndex) {
-                newCollectionList[index] = updateElement(collectionList[moveIndex], index);
-                shift = moveIndex < elIndex ? 0 : -1;
-            } else if (index == moveIndex && moveIndex < elIndex) {
-                shift = 1;
-                newCollectionList[index] = updateElement(collectionList[index + shift], index);
-            } else if (index == moveIndex && moveIndex > elIndex) {
-                newCollectionList[index] = updateElement(collectionList[index + shift], index);
-                shift = 0;
-            } else {
-                newCollectionList[index] = updateElement(collectionList[index + shift], index);
-            }
-        });
-        collectionList.remove();
-        $.each(newCollectionList, function (index, element) {
-            $("table").append(element);
-        });
-        $.ajax({
-            type: "GET",
-            url: moveUrl,
-            success: responseData => {
-                console.log("Collection's changed order is persisted to the backend.");
-            },
-            error: responseData => console.log("Cannot change collections order " + responseData)
-        });
+function before_add_element(element, index) {
+    //Write script that will run before add ellement to table
+    label = element.getElementsByClassName("label");
+    if (label.length !== 0){
+        labelItem = label.item(0);
+        labelItem.innerHTML = element.getAttribute("labelstring") + index;
     }
 }
 
-// Handler function of the drag over process
-function dragover_handler(event) {
-    event.preventDefault();
-    // Set the dropEffect to move
-    event.dataTransfer.dropEffect = "move";
+function is_forbidden_to_chage(dataset, data) {
+    elAtype = dataset.atype;
+    moveAtype = data[2];
+    if (moveAtype !== elAtype || elAtype === "G" || moveAtype === "G"){
+        return true
+    }
+    return false
 }
 
-// Handler function of the drag start process
-function dragstart_handler(event) {
-    event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url + ',' + event.target.dataset.atype);
-    event.dropEffect = "move";
+function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
+    // Function that work with event.dataTransfer and event_target_dataset. Example:
+    //  event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
+    event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url + ',' + event_target_dataset.atype);
 }

--- a/bridge_adaptivity/module/static/module/js/drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/drag_drop.js
@@ -2,6 +2,6 @@
 
 function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
     // Function that work with event.dataTransfer and event_target_dataset. Example:
-    //  event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
+    //  event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
     event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url)
 }

--- a/bridge_adaptivity/module/static/module/js/drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/drag_drop.js
@@ -1,63 +1,7 @@
-// Utility function which exchange element's index
-function updateElement(element, index) {
-    element.dataset.index = index;
-    return element;
-}
+// include base_drag_drop.js before this script
 
-// Function processing drop of the element
-function drop_handler(event, el) {
-    event.preventDefault();
-    let data = event.dataTransfer.getData("text/plain").split(','),
-        elIndex = el.dataset.index, // index of the target element
-        moveUrl = data[1], // move URL of the dropped element
-        moveIndex = data[0]; // initial index of the dropped element
-    if (moveIndex === elIndex) {
-        console.log("Item doesn't change the order");
-    } else {
-        console.log("Trying change Item " + moveIndex + " order to " + elIndex);
-        moveUrl = moveUrl.replace("?", elIndex + "?");
-        let collectionList = $('tr.droppable'),
-            shift = 0,
-            newCollectionList = [];
-        // Update elements order on the frontend
-        $.each(collectionList, function (index, _) {
-            if (index == elIndex) {
-                newCollectionList[index] = updateElement(collectionList[moveIndex], index);
-                shift = moveIndex < elIndex ? 0 : -1;
-            } else if (index == moveIndex && moveIndex < elIndex) {
-                shift = 1;
-                newCollectionList[index] = updateElement(collectionList[index + shift], index);
-            } else if (index == moveIndex && moveIndex > elIndex) {
-                newCollectionList[index] = updateElement(collectionList[index + shift], index);
-                shift = 0;
-            } else {
-                newCollectionList[index] = updateElement(collectionList[index + shift], index);
-            }
-        });
-        collectionList.remove();
-        $.each(newCollectionList, function (index, element) {
-            $("table").append(element);
-        });
-        $.ajax({
-            type: "GET",
-            url: moveUrl,
-            success: responseData => {
-                console.log("Collection's changed order is persisted to the backend.");
-            },
-            error: responseData => console.log("Cannot change collections order " + responseData)
-        });
-    }
-}
-
-// Handler function of the drag over process
-function dragover_handler(event) {
-    event.preventDefault();
-    // Set the dropEffect to move
-    event.dataTransfer.dropEffect = "move";
-}
-
-// Handler function of the drag start process
-function dragstart_handler(event) {
-    event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
-    event.dropEffect = "move";
+function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
+    // Function that work with event.dataTransfer and event_target_dataset. Example:
+    //  event.dataTransfer.setData("text/plain", event.target.dataset.index + ',' + event.target.dataset.move_url);
+    event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url)
 }

--- a/bridge_adaptivity/module/static/module/js/drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/drag_drop.js
@@ -2,6 +2,6 @@
 
 function set_event_data_transfer_from_event_target_dataset(event_data_transfer, event_target_dataset) {
     // Function that work with event.dataTransfer and event_target_dataset. Example:
-    //  event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
+    // event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url);
     event_data_transfer.setData("text/plain", event_target_dataset.index + ',' + event_target_dataset.move_url)
 }

--- a/bridge_adaptivity/module/templates/module/collection_detail.html
+++ b/bridge_adaptivity/module/templates/module/collection_detail.html
@@ -70,21 +70,22 @@
           </tr>
           {% for activity in activities %}
             <tr id="activity-row-{{ forloop.counter0 }}"
-                class="activity  droppable {% if activity.atype == 'A' %}warning{% elif activity.atype == 'Z' %}info{% endif %}"
+                class="activity droppable {% if activity.atype == 'A' %}warning{% elif activity.atype == 'Z' %}info{% endif %}"
                 data-activity-name="{{ activity.name }}"
                 data-id="{{ activity.id }}"
                 data-activity-source-launch-url="{{ activity.source_launch_url }}"
                 data-content_source_id="{{ activity.lti_consumer.id }}"
                 data-source-active="{% if activity.lti_consumer.is_active %}true{% endif %}"
-
-                draggable="{% if activity.atype != 'G' %}true{% endif %}"
-                ondrop="drop_handler(event, this);"
-                ondragstart="dragstart_handler(event);"
-                ondragover="dragover_handler(event);"
-                data-index="{{ forloop.counter0 }}"
-                data-move_url="{% url 'module:activity-move' pk=activity.pk  %}?back_url={{ activity.get_absolute_url}}"
-                data-atype="{{activity.atype}}"
-                labelstring="{% if activity.atype == 'A' %}PRE:{% elif activity.atype == 'Z' %}POST:{% endif %}"
+                {% if not request.session.read_only_data %}
+                    draggable="{% if activity.atype != 'G' %}true{% endif %}"
+                    ondrop="drop_handler(event, this);"
+                    ondragstart="dragstart_handler(event);"
+                    ondragover="dragover_handler(event);"
+                    data-index="{{ forloop.counter0 }}"
+                    data-move_url="{% url 'module:activity-move' pk=activity.pk  %}?back_url={{ activity.get_absolute_url}}"
+                    data-atype="{{activity.atype}}"
+                    labelstring="{% if activity.atype == 'A' %}PRE:{% elif activity.atype == 'Z' %}POST:{% endif %}"
+                {% endif %}
 
             >
                 {% url 'module:activity-change' activity.pk collection.slug as activity_edit %}
@@ -124,20 +125,6 @@
                       {% bootstrap_button "" size='sm' icon='edit' extra_classes='modal_launcher' value=activity_edit %}
                       </a>
                   {% endif %}
-                  {% ifnotequal activity.atype 'G' %}
-                    {% ifnotequal activity.order 0 %}
-                    <a class="move-up pull-right"
-                       href="{% url 'module:activity-move' pk=activity.pk direction='up' %}">
-                      {% bootstrap_button "" size='sm' icon='chevron-up' %}
-                    </a>
-                    {% endifnotequal %}
-                    {% if not forloop.last and not activity.last_pre  %}
-                      <a class="move-down pull-right"
-                         href="{% url 'module:activity-move' pk=activity.pk direction='down' %}">
-                        {% bootstrap_button "" size='sm' icon='chevron-down' %}
-                      </a>
-                    {% endif %}
-                  {% endifnotequal %}
                 </div>
               </td>
             </tr>
@@ -282,6 +269,8 @@
 {% block bootstrap3_extra_script %}
   {{ block.super }}
   <script src="{% static 'module/js/module.js' %}"></script>
-  <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
-  <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
+  {% if not request.session.read_only_data %}
+    <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
+    <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
+  {% endif %}
 {% endblock bootstrap3_extra_script %}

--- a/bridge_adaptivity/module/templates/module/collection_detail.html
+++ b/bridge_adaptivity/module/templates/module/collection_detail.html
@@ -68,12 +68,21 @@
           </tr>
           {% for activity in activities %}
             <tr id="activity-row-{{ forloop.counter0 }}"
-                class="activity {% if activity.atype == 'A' %}warning{% elif activity.atype == 'Z' %}info{% endif %}"
+                class="activity  droppable {% if activity.atype == 'A' %}warning{% elif activity.atype == 'Z' %}info{% endif %}"
                 data-activity-name="{{ activity.name }}"
                 data-id="{{ activity.id }}"
                 data-activity-source-launch-url="{{ activity.source_launch_url }}"
                 data-content_source_id="{{ activity.lti_consumer.id }}"
                 data-source-active="{% if activity.lti_consumer.is_active %}true{% endif %}"
+
+                draggable="{% if activity.atype != 'G' %}true{% endif %}"
+              ondrop="drop_handler(event, this);"
+              ondragstart="dragstart_handler(event);"
+              ondragover="dragover_handler(event);"
+              data-index="{{ forloop.counter0 }}"
+              data-move_url="{% url 'module:activity-move' pk=activity.pk  %}?back_url={{ activity.get_absolute_url}}"
+               data-atype="{{activity.atype}}"
+
             >
                 {% url 'module:activity-change' activity.pk collection.slug as activity_edit %}
               <td class="text-left modal_launcher" value="{{ activity_edit }}">
@@ -110,20 +119,6 @@
                   <a class="pull-right">
                   {% bootstrap_button "" size='sm' icon='edit' extra_classes='modal_launcher' value=activity_edit %}
                   </a>
-                  {% ifnotequal activity.atype 'G' %}
-                    {% ifnotequal activity.order 0 %}
-                    <a class="move-up pull-right"
-                       href="{% url 'module:activity-move' pk=activity.pk direction='up' %}">
-                      {% bootstrap_button "" size='sm' icon='chevron-up' %}
-                    </a>
-                    {% endifnotequal %}
-                    {% if not forloop.last and not activity.last_pre  %}
-                      <a class="move-down pull-right"
-                         href="{% url 'module:activity-move' pk=activity.pk direction='down' %}">
-                        {% bootstrap_button "" size='sm' icon='chevron-down' %}
-                      </a>
-                    {% endif %}
-                  {% endifnotequal %}
                 </div>
               </td>
             </tr>
@@ -266,4 +261,5 @@
 {% block bootstrap3_extra_script %}
   {{ block.super }}
   <script src="{% static 'module/js/module.js' %}"></script>
+    <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
 {% endblock bootstrap3_extra_script %}

--- a/bridge_adaptivity/module/templates/module/collection_detail.html
+++ b/bridge_adaptivity/module/templates/module/collection_detail.html
@@ -82,6 +82,7 @@
                 data-index="{{ forloop.counter0 }}"
                 data-move_url="{% url 'module:activity-move' pk=activity.pk  %}?back_url={{ activity.get_absolute_url}}"
                 data-atype="{{activity.atype}}"
+                labelstring="{% if activity.atype == 'A' %}PRE:{% elif activity.atype == 'Z' %}POST:{% endif %}"
 
             >
                 {% url 'module:activity-change' activity.pk collection.slug as activity_edit %}
@@ -261,5 +262,6 @@
 {% block bootstrap3_extra_script %}
   {{ block.super }}
   <script src="{% static 'module/js/module.js' %}"></script>
+  <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
   <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
 {% endblock bootstrap3_extra_script %}

--- a/bridge_adaptivity/module/templates/module/collection_detail.html
+++ b/bridge_adaptivity/module/templates/module/collection_detail.html
@@ -268,8 +268,8 @@
 
 {% block bootstrap3_extra_script %}
   {{ block.super }}
-  <script src="{% static 'module/js/module.js' %}"></script>
-  {% if not request.session.read_only_data %}
+{% if not request.session.read_only_data %}
+    <script src="{% static 'module/js/module.js' %}"></script>
     <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
     <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
   {% endif %}

--- a/bridge_adaptivity/module/templates/module/collection_detail.html
+++ b/bridge_adaptivity/module/templates/module/collection_detail.html
@@ -76,12 +76,12 @@
                 data-source-active="{% if activity.lti_consumer.is_active %}true{% endif %}"
 
                 draggable="{% if activity.atype != 'G' %}true{% endif %}"
-              ondrop="drop_handler(event, this);"
-              ondragstart="dragstart_handler(event);"
-              ondragover="dragover_handler(event);"
-              data-index="{{ forloop.counter0 }}"
-              data-move_url="{% url 'module:activity-move' pk=activity.pk  %}?back_url={{ activity.get_absolute_url}}"
-               data-atype="{{activity.atype}}"
+                ondrop="drop_handler(event, this);"
+                ondragstart="dragstart_handler(event);"
+                ondragover="dragover_handler(event);"
+                data-index="{{ forloop.counter0 }}"
+                data-move_url="{% url 'module:activity-move' pk=activity.pk  %}?back_url={{ activity.get_absolute_url}}"
+                data-atype="{{activity.atype}}"
 
             >
                 {% url 'module:activity-change' activity.pk collection.slug as activity_edit %}
@@ -261,5 +261,5 @@
 {% block bootstrap3_extra_script %}
   {{ block.super }}
   <script src="{% static 'module/js/module.js' %}"></script>
-    <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
+  <script src="{% static 'module/js/collection_drag_drop.js' %}"></script>
 {% endblock bootstrap3_extra_script %}

--- a/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
+++ b/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
@@ -49,12 +49,14 @@
           {% if request.session.read_only_data and collection.slug != request.session.read_only_data.collection %}
             {# Continue #}
           {% else %}
-              <tr draggable="true" class="droppable"
-                  ondrop="drop_handler(event, this);"
-                  ondragstart="dragstart_handler(event);"
-                  ondragover="dragover_handler(event);"
-                  data-index="{{ forloop.counter0 }}"
-                  data-move_url="{% url 'module:collection-move' group_slug=group.slug slug=collection.slug %}?back_url={{ group.get_absolute_url}}"
+              <tr {% if not request.session.read_only_data %}
+                      draggable="true" class="droppable"
+                      ondrop="drop_handler(event, this);"
+                      ondragstart="dragstart_handler(event);"
+                      ondragover="dragover_handler(event);"
+                      data-index="{{ forloop.counter0 }}"
+                      data-move_url="{% url 'module:collection-move' group_slug=group.slug slug=collection.slug %}?back_url={{ group.get_absolute_url}}"
+                  {% endif %}
               >
                 <td>
                   <a href="{% url 'module:collection-detail' collection.id %}?back_url={{ group.get_absolute_url}}">
@@ -213,6 +215,8 @@
 {% block bootstrap3_extra_script %}
   {{ block.super }}
   <script src="{% static 'module/js/module.js' %}"></script>
-  <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
-  <script src="{% static 'module/js/drag_drop.js' %}"></script>
+  {% if not request.session.read_only_data %}
+    <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
+    <script src="{% static 'module/js/drag_drop.js' %}"></script>
+  {% endif %}
 {% endblock bootstrap3_extra_script %}

--- a/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
+++ b/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
@@ -214,8 +214,8 @@
 
 {% block bootstrap3_extra_script %}
   {{ block.super }}
-  <script src="{% static 'module/js/module.js' %}"></script>
   {% if not request.session.read_only_data %}
+    <script src="{% static 'module/js/module.js' %}"></script>
     <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
     <script src="{% static 'module/js/drag_drop.js' %}"></script>
   {% endif %}

--- a/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
+++ b/bridge_adaptivity/module/templates/module/collectiongroup_detail.html
@@ -203,5 +203,6 @@
 {% block bootstrap3_extra_script %}
   {{ block.super }}
   <script src="{% static 'module/js/module.js' %}"></script>
+  <script src="{% static 'module/js/base_drag_drop.js' %}"></script>
   <script src="{% static 'module/js/drag_drop.js' %}"></script>
 {% endblock bootstrap3_extra_script %}

--- a/bridge_adaptivity/module/urls.py
+++ b/bridge_adaptivity/module/urls.py
@@ -66,7 +66,7 @@ urlpatterns = ([
         name='activity-change'
     ),
     url(
-        r'^activity/(?P<pk>\d+)/move/(?P<order>\d+)?$$',
+        r'^activity/(?P<pk>\d+)/move/(?P<order>\d+)?$',
         ActivityUpdate.as_view(),
         name='activity-move'
     ),

--- a/bridge_adaptivity/module/urls.py
+++ b/bridge_adaptivity/module/urls.py
@@ -66,7 +66,7 @@ urlpatterns = ([
         name='activity-change'
     ),
     url(
-        r'^activity/(?P<pk>\d+)/move/(?P<direction>(up|down))/$',
+        r'^activity/(?P<pk>\d+)/move/(?P<order>\d+)?$$',
         ActivityUpdate.as_view(),
         name='activity-move'
     ),

--- a/bridge_adaptivity/module/views.py
+++ b/bridge_adaptivity/module/views.py
@@ -384,14 +384,12 @@ class ActivityUpdate(CollectionSlugToContextMixin, ModalFormMixin, UpdateView):
 
     def get(self, request, *args, **kwargs):
         activity = self.get_object()
-        if kwargs.get('direction'):
+        if kwargs.get('order'):
             try:
-                # NOTE(wowkalucky): expects 'up', 'down' (also possible: 'top', 'bottom')
-                getattr(activity, kwargs['direction'])()
+                getattr(activity, 'to')(int(kwargs['order']))
             except AttributeError:
                 log.exception("Unknown ordering method!")
-            return redirect(reverse('module:collection-detail', kwargs={'pk': activity.collection.id}))
-
+            return HttpResponse(status=201)
         return super().get(request, *args, **kwargs)
 
 


### PR DESCRIPTION
*Description:* Add Drag&Drop feature for `pre-/post-assessment` activities in collection detailed view
*Task:* 
Jira: https://vpalresearch.atlassian.net/browse/AD-262 
Youtrack: https://youtrack.raccoongang.com/issue/ALOSI-28