### PR TITLE
Reduce db queries in Log admin views

### DIFF
--- a/bridge_adaptivity/module/admin.py
+++ b/bridge_adaptivity/module/admin.py
@@ -84,7 +84,16 @@ class GradingPolicyAdmin(admin.ModelAdmin):
 
 @admin.register(Log)
 class LogAdmin(admin.ModelAdmin):
-    pass
+    readonly_fields = (
+        'sequence_item',  # populating dropdown may not be feasible for large number of available sequence items
+    )
+    # reduces number of db queries
+    list_select_related = (
+        'sequence_item',
+        'sequence_item__activity',
+        'sequence_item__sequence',
+        'sequence_item__sequence__lti_user',
+    )
 
 
 class GroupStackedInline(admin.StackedInline):


### PR DESCRIPTION
Optimize the Log admin views by reducing the number of database queries made. The sequence_item field in the detail view is made read-only, to prevent a potentially large dropdown menu from being populated (can cause problems loading if there are many sequence items).