### PR TITLE
Filter collection and activity api by field

### DIFF
--- a/bridge_adaptivity/api/views.py
+++ b/bridge_adaptivity/api/views.py
@@ -69,6 +69,7 @@ class ActivityViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = ActivitySerializer
+    filter_fields = ['source_launch_url']
 
     def get_queryset(self):
         """
@@ -86,6 +87,7 @@ class CollectionViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = CollectionSerializer
+    filter_fields = ['slug']
 
     def get_queryset(self):
         """

--- a/bridge_adaptivity/api/views.py
+++ b/bridge_adaptivity/api/views.py
@@ -69,7 +69,7 @@ class ActivityViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = ActivitySerializer
-    filter_fields = ['source_launch_url']
+    filter_fields = ['collection', 'source_launch_url']
 
     def get_queryset(self):
         """

--- a/bridge_adaptivity/config/settings/base.py
+++ b/bridge_adaptivity/config/settings/base.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = (
     'rest_framework',
     'rest_framework.authtoken',
     'multiselectfield',
+    'django_filters',
 
     # core functions
     'bridge_lti',
@@ -182,6 +183,9 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/bridge_adaptivity/requirements_base.txt
+++ b/bridge_adaptivity/requirements_base.txt
@@ -8,6 +8,7 @@ django-multiselectfield==0.1.8
 django-ordered-model==1.4.3
 djangorestframework==3.7.7
 django-slugger==1.0.4
+django-filter==2.1.0
 
 edx-rest-api-client==1.7.1
 lti==0.9.2


### PR DESCRIPTION
Adds filtering to collection and activity api list API endpoints, via django rest framework / django-filters. For collection, filtering by `slug` field is enabled. For activity, filtering by `collection` and `source_launch_url` fields is enabled. These are useful when populating collections/activities via API, to determine whether an object with particular field values already exists, without requesting a full unfiltered list of objects (potentially can return large number of objects).

Collection:
- filter by `slug` field
- Example:
    - request: GET `http://localhost:8008/api/collection/?slug=test_collection2`
    - response: collection object list (should have length <=1)

Activity: 
- filter by `collection` and/or `source_launch_url`
- Example:
    - request: GET `http://localhost:8008/api/activity/?collection=1&source_launch_url=https%3A%2F%2Fcourses.openedx.example.com%2Flti_provider%2Fcourses%2Fcourse-v1%3AVPAL%2BBFA%2B2018%2Fblock-v1%3AVPAL%2BBFA%2B2018%2Btype%40problem%2Bblock%4068b0f22d55084b04b5e8a834e0989278`
    - response: activity object list
- note: url argument should be made url-safe, e.g. with `urllib.parse.quote_plus`