### PR TITLE
Encoding unsupported characters in URL

### DIFF
--- a/bridge_adaptivity/module/static/module/js/module.js
+++ b/bridge_adaptivity/module/static/module/js/module.js
@@ -233,7 +233,7 @@
 
         function configurePreview(title, ltiUrl, sourceId, contentSourceId, modalFrame) {
             var idParam = "source_id=" + sourceId + "&";
-            var displayNameParam = "source_name=" + title + "&";
+            var displayNameParam = "source_name=" + encodeURIComponent(title) + "&";
             var ltiUrlParam = "source_lti_url=" + ltiUrl + "&";
             var contentSourceIdParam = "content_source_id=" + contentSourceId + "&";
             var previewUrl = (


### PR DESCRIPTION
*Description*
Enable the use of ‘#' characters in the activity name field by encoding unsupported characters in URL

*Task*
https://vpalresearch.atlassian.net/browse/AD-269
https://youtrack.raccoongang.com/issue/ALOSI-43