### PR TITLE
Add optimized dockerfile

### DIFF
--- a/bridge_adaptivity/Dockerfile_opt
+++ b/bridge_adaptivity/Dockerfile_opt
@@ -1,0 +1,16 @@
+# Dockerfile for bridge-adaptivity that installs prod requirements before copying other files to image
+# to take advantage of layer caching for potentially faster rebuilds/pushes
+
+FROM python:3.6
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /bridge_adaptivity
+
+# Install requirements:
+COPY requirements.txt .
+COPY requirements_base.txt .
+RUN pip install -r requirements.txt
+
+ADD . .
+
+EXPOSE 8000


### PR DESCRIPTION
Adds an alternate Dockerfile, `Dockerfile_opt`, that installs prod requirements before copying other files to image, to take advantage of layer caching for potentially faster rebuilds/pushes. (Could replace `Dockerfile` with this)