### PR TITLE
Fix showing modal form for deleting collection

### DIFF
--- a/bridge_adaptivity/module/templates/module/collection_detail.html
+++ b/bridge_adaptivity/module/templates/module/collection_detail.html
@@ -38,7 +38,7 @@
                              show-alarm {% else %} show-warning
                            {% endif %}
                          {% endif %}"
-                   data-id="{{ collection.slug }}">
+                   data-id="{{ collection.id }}">
                     {% bootstrap_button "Delete" size='sm' icon='trash' %}
                 </a>
                  {% endif %}


### PR DESCRIPTION
Description: Fix showing modal form for deleting the collection.  "data-id" is used for founding modal form with id = deleteModal{{data-id}}. 
Tasks: https://youtrack.raccoongang.com/issue/ALOSI-90