### PR TITLE
Add daphne as asgi web server for django channels.

### DIFF
--- a/bridge_adaptivity/config/asgi.py
+++ b/bridge_adaptivity/config/asgi.py
@@ -1,11 +1,12 @@
 """
-ASGI entrypoint. Configures Django and then runs the application
-defined in the ASGI_APPLICATION setting.
+ASGI entrypoint. Configures Django and then runs the application defined in the ASGI_APPLICATION setting.
 """
 
 import os
-import django
+
 from channels.routing import get_default_application
+import django
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
 django.setup()

--- a/bridge_adaptivity/config/asgi.py
+++ b/bridge_adaptivity/config/asgi.py
@@ -1,0 +1,12 @@
+"""
+ASGI entrypoint. Configures Django and then runs the application
+defined in the ASGI_APPLICATION setting.
+"""
+
+import os
+import django
+from channels.routing import get_default_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
+django.setup()
+application = get_default_application()

--- a/bridge_adaptivity/docker-compose-stage.yml
+++ b/bridge_adaptivity/docker-compose-stage.yml
@@ -10,3 +10,6 @@ services:
 
   nginx:
     image: bridge-nginx:stage
+
+  bridge_web_socket:
+    image: bridge_adaptivity:stage

--- a/bridge_adaptivity/docker-compose.yml
+++ b/bridge_adaptivity/docker-compose.yml
@@ -45,6 +45,19 @@ services:
       - postgres
       - rabbit
 
+  bridge_web_socket:
+    image: bridge_adaptivity
+    depends_on:
+      - postgres
+      - worker
+      - redis
+    volumes:
+      - .:/bridge_adaptivity
+    ports:
+      - "8001:8001"
+    entrypoint: ""
+    command: daphne -b 0.0.0.0 -p 8001 config.asgi:application
+
   rabbit:
     container_name: rabbitmq
     image: rabbitmq

--- a/bridge_adaptivity/module/routing.py
+++ b/bridge_adaptivity/module/routing.py
@@ -4,5 +4,5 @@ from django.conf.urls import url
 from . import consumers
 
 websocket_urlpatterns = [
-    url(r'^sequence/(?P<sequence_item>[^/]+)/$', consumers.NextButtonConsumer),
+    url(r'^ws/sequence/(?P<sequence_item>[^/]+)/$', consumers.NextButtonConsumer),
 ]

--- a/bridge_adaptivity/module/static/module/js/forbid_next.js
+++ b/bridge_adaptivity/module/static/module/js/forbid_next.js
@@ -33,7 +33,7 @@ var update_ui_details = function(uiDetailsArray){
     if(sequence_item && is_disabled){
         var ws_scheme = window.location.protocol == "https:" ? "wss" : "ws";
         var buttonSocket = new WebSocket(
-            ws_scheme + '://' +  window.location.host + '/sequence/'+ sequence_item + '/'
+            ws_scheme + '://' +  window.location.host + '/ws/sequence/'+ sequence_item + '/'
         );
          console.log("Next button channel run");
         buttonSocket.onmessage = function(e) {

--- a/bridge_adaptivity/nginx/stage/bridge.conf
+++ b/bridge_adaptivity/nginx/stage/bridge.conf
@@ -1,5 +1,13 @@
+upstream bridge-backend {
+    server bridge:8000;
+}
+
+upstream channels-backend {
+    server bridge_web_socket:8001;
+}
+
 server {
-        listen 443 default_server ssl;
+        listen 443 ssl http2;
         ssl_certificate         /etc/nginx/ssl/raccoongang.crt;
         ssl_certificate_key     /etc/nginx/ssl/raccoongang.key;
         ssl_protocols           TLSv1 TLSv1.1 TLSv1.2;
@@ -17,12 +25,27 @@ server {
         location /static {
                 alias /www/static;
         }
+        location /ws/ {
+              proxy_set_header X-Forwarded-Proto $scheme;
+              proxy_set_header X-Forwarded-Port $server_port;
+              proxy_set_header X-Forwarded-For $remote_addr;
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Original-URI $request_uri;
+              real_ip_recursive on;
+              proxy_http_version 1.1;
+              proxy_set_header Host $http_host;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "upgrade";
+              proxy_read_timeout 86400;
+              proxy_redirect off;
+              proxy_pass http://channels-backend;
+        }
         location / {
                 proxy_set_header X-Forwarded-Proto $scheme;
                 proxy_set_header X-Forwarded-Port $server_port;
                 proxy_set_header X-Forwarded-For $remote_addr;
                 proxy_set_header Host $http_host;
                 proxy_redirect off;
-                proxy_pass http://bridge:8000;
+                proxy_pass http://bridge-backend;
         }
 }

--- a/bridge_adaptivity/requirements_local.txt
+++ b/bridge_adaptivity/requirements_local.txt
@@ -14,6 +14,7 @@ django-sslserver
 flake8==3.4.1
 tox==2.7.0
 pbr==3.1.1
+cryptography
 
 pytest
 pytest-django


### PR DESCRIPTION
Description:  Setuped Daphne as the asgi web server for Django channels and configured Nginx for enabling proxying WebSocket. 
Tasks: 
https://youtrack.raccoongang.com/issue/ALOSI-93
https://vpalresearch.atlassian.net/browse/AD-280

Note: All Nginx will have to configureted to proxying Websockets.