### PR TITLE
[ALOSI] Change version of psycopg2. Fix bug in nginx stage configuration

### DIFF
--- a/bridge_adaptivity/nginx/stage/bridge.conf
+++ b/bridge_adaptivity/nginx/stage/bridge.conf
@@ -1,5 +1,5 @@
 upstream bridge-backend {
-    server bridge:8000;
+    server BFA:8000;
 }
 
 upstream channels-backend {

--- a/bridge_adaptivity/requirements_base.txt
+++ b/bridge_adaptivity/requirements_base.txt
@@ -13,7 +13,7 @@ django-filter==2.1.0
 edx-rest-api-client==1.7.1
 lti==0.9.2
 requests==2.20.1
-psycopg2==2.7.3
+psycopg2==2.8.3
 shortuuid==0.5.0  # https://github.com/skorokithakis/shortuuid
 
 # sentry monitoring requirements


### PR DESCRIPTION
Description: 

- Change psycopg2 version, because with the old version exception happened with massage:
`django.core.exceptions.ImproperlyConfigured: Error loading psycopg2 module: /usr/local/lib/python3.6/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference`
With version psycopg2==2.8.3 avarising is ok.

- Change mistake in stage nginx settings

Tasks: https://youtrack.raccoongang.com/issue/ALOSI-109