### PR TITLE
[ALOSI-140] Refreshing index and atype variable after writing indexes.

### DIFF
--- a/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
+++ b/bridge_adaptivity/module/static/module/js/collection_drag_drop.js
@@ -1,11 +1,12 @@
 // WARNING(AndreyLykhoman):include base_drag_drop.js before this script
 
-before_add_element = function() {
+// NOTE(AndreyLykhoman): before_add_element, after_add_elements methods are used in base_drag_drop.js lines: 62 and 65.
+[before_add_element, after_add_elements] = function() {
     // Write a script that will be run before adding an ellement to the table
     // NOTE(AndreyLykhoman): Checking atype of elements and increase index or starting from zero
     atype = '';
     index = 0;
-    return function (element) {
+    return [function (element) {
         label = element.getElementsByClassName("label");
         if (label.length !== 0) {
             labelstring = element.getAttribute("data-atype");
@@ -21,7 +22,12 @@ before_add_element = function() {
             labelItem = label.item(0);
             labelItem.innerHTML = element.getAttribute("labelstring") + index;
         }
-    }
+    },
+      function () {
+        // NOTE(AndreyLykhoman): Clear atype and index after writing indexes.
+        atype = '';
+        index = 0;
+    }]
 }();
 
 function change_move_url(moveUrl, element_dataset) {


### PR DESCRIPTION
**Description**:  *Added `after_add_elements` function for refrashing `index` and `atype` variable.* 
The `after_add_elements`  and  `before_add_element` function returned by anonymous function.  This is needs because I use the Closures in two functions. These functions need to work with the same variables:  `index` and `atype`. The `before_add_element` function uses `index` and `atype`,   `after_add_elements` refrashes `index` and `atype` to default value.
The plase where these functions are used: 
 - before_add_element  https://github.com/harvard-vpal/bridge-adaptivity/blob/master/bridge_adaptivity/module/static/module/js/base_drag_drop.js#L62
 - after_add_elements https://github.com/harvard-vpal/bridge-adaptivity/blob/master/bridge_adaptivity/module/static/module/js/base_drag_drop.js#L65

**Tasks**: https://youtrack.raccoongang.com/issue/ALOSI-140